### PR TITLE
chore: added eidas complex examples

### DIFF
--- a/sd_jwt/examples/complex_eidas.yml
+++ b/sd_jwt/examples/complex_eidas.yml
@@ -1,0 +1,81 @@
+user_claims:
+  {
+    "verified_claims":
+      {
+        "verification":
+          {
+            "trust_framework": "eidas",
+            "assurance_level": "high",
+            "evidence":
+              [
+                {
+                  "type": "document",
+                  "time": "2022-04-22T11:30Z",
+                  "document":
+                    {
+                      "type": "idcard",
+                      "issuer": {
+                        "name": "c_d612", # italian ipa code, public service id.
+                        "country": "IT"
+                      },
+                      "number": "154554",
+                      "date_of_issuance": "2021-03-23",
+                      "date_of_expiry": "2031-03-22",
+                    },
+                },
+              ],
+          },
+        "claims": {
+          "person_unique_identifier": "TINIT-fc0d9684-1bf0-4220-9642-8fe652c8c040",
+          "given_name": "Raffaello",
+          "family_name": "Mascetti",
+          "date_of_birth": "1922-03-13",
+          "gender": "M",
+          "place_of_birth": {
+            "country": "IT",
+            "locality": "Firenze"
+          },
+          "nationalities": [
+            "IT"
+          ]
+        }
+      },
+    "birth_middle_name": "Lello",
+  }
+
+claims_structure:
+  {
+    "verified_claims":
+      {
+        "verification": { 
+            "trust_framework": "", 
+            "evidence": [{ "document": { "issuer": {} } }] 
+        },
+        "claims": { 
+            "person_unique_identifier": "",
+            "given_name": "", 
+            "family_name": "", 
+            "nationalities": "" 
+        },
+      },
+  }
+
+disclosed_claims:
+  {
+    "verified_claims":
+      {
+        "verification":
+          {
+            "trust_framework": null
+          },
+        "claims":
+          {
+            "person_unique_identifier": null,
+            "given_name": null,
+            "family_name": null,
+            "nationalities": null,
+            "gender": null,
+            "place_of_birth": { "country": null },
+          },
+      },
+  }

--- a/sd_jwt/examples/complex_eidas_proposal.yml
+++ b/sd_jwt/examples/complex_eidas_proposal.yml
@@ -1,0 +1,80 @@
+user_claims:
+  {
+    "verified_claims":
+      {
+        "verification":
+          {
+            "trust_framework": "eidas",
+            "assurance_level": "high",
+            "evidence": [
+                {
+                  "type": "electronic_record",
+                  "record": {
+                    "type": "eu.europa.ec.eudiw.pid.1",
+                    "source": {
+                        "organization_name": "Comune di Firenze",
+                        "organization_id": "c_d612", # italian ipa code, public service id.
+                        "country_code": "IT",
+                        "country": "Italy"
+                    },
+                    "personal_number": "9642-8fe652c8c040" # european personal id
+                  }
+                }
+            ]
+          },
+        "claims": {
+          "person_unique_identifier": "TINIT-fc0d9684-1bf0-4220-9642-8fe652c8c040",
+          "given_name": "Raffaello",
+          "family_name": "Mascetti",
+          "date_of_birth": "1922-03-13",
+          "gender": "M",
+          "place_of_birth": {
+            "country": "IT",
+            "locality": "Firenze"
+          },
+          "nationalities": [
+            "IT"
+          ]
+        }
+      },
+    "birth_middle_name": "Lello", # other optional claim not covered by eu.europa.ec.eudiw.pid.1
+  }
+
+claims_structure:
+  {
+    "verified_claims":
+      {
+        "verification": { 
+            "trust_framework": "", 
+            "evidence": [{ "record": { "record": {"type": ""} } }] 
+        },
+        "claims": { 
+            "person_unique_identifier": "",
+            "given_name": "", 
+            "family_name": "", 
+            "nationalities": "" 
+        },
+      },
+  }
+
+disclosed_claims:
+  {
+    "verified_claims":
+      {
+        "verification":
+          {
+            "trust_framework": null,
+            "assurance_level": null,
+            "evidence": [{ "record": {"type": null} }] 
+          },
+        "claims":
+          {
+            "person_unique_identifier": null,
+            "given_name": null,
+            "family_name": null,
+            "nationalities": null,
+            "gender": null,
+            "place_of_birth": { "country": null },
+          },
+      },
+  }


### PR DESCRIPTION
An excercise to define a kind of eIDAS PID docType in SD-JWT using OIDC Identity assurance ... without the adoption on JWT-VC [vc-data-model] for now.