### PR TITLE
Ensure documents are alphabetically sorted when claim names are blinded

### DIFF
--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -936,18 +936,69 @@ TBD
 ## Blinding Claim Names {#blinding-claim-names}
 
 Issuers that chose to blind claim names MUST ensure not to inadvertently leak
-information about the blinded claim names to verifiers. In particular, issuers
-MUST choose placeholder claim names accordingly.
+information about the blinded claim names to verifiers. 
 
 It is RECOMMENDED to use cryptographically salts with at least 128 bits
 of entropy as placeholder claim names.
 
-The order of elements in JSON-encoded objects is not relevant to
-applications, but the order may reveal information about the blinded
-claim name to the verifier. It is therefore RECOMMENDED to ensure that
-the claims in the SD-JWT, II-Disclosures object, and HS-Disclosures JWT
-is shuffled or otherwise hidden, e.g., by alphabetically sorting using
-the blinded claim names.
+The order of elements in JSON-encoded objects is generally not relevant
+to applications, but it may reveal information about a blinded claim
+name to the verifier. For example, assume the following two clear-text
+claim sets created by the same Issuer:
+
+(A)
+```
+{
+  "given_name": "Doe",
+  "secret_club_membership_no": 42
+}
+```
+
+(B)
+```
+{
+  "is_secret_agent": true,
+  "given_name": "Doe"
+}
+```
+
+When naively blinding the claim names, the order of the elements might
+be preserved in the SD-JWT (depending on implementation details of the
+programming language):
+
+
+(A)
+```
+{
+  "given_name": "Doe",
+  "3DOgmo7w7MDZNh1Zjvmwpg":
+    "OXZKGG7Ltar4vz_L7sAtWIkVXVf5r9xONFKZdyoNlco"
+}
+```
+
+(B)
+```
+{
+  "CwiB46IUgi4NydIfgGTRwg":
+    "4miZg7O_JaidVJyjGiPpc4FXAMN16e1SBZfOMlYg3hQ",
+  "given_name": "Doe"
+}
+```
+
+A verifier, even if it does not learn any blinded claim names, can
+distinguish what claim name has been hidden just by observing the order
+of blinded and unblinded claim names. It is therefore RECOMMENDED, if at
+least one claim name is blinded, to either 
+
+ * randomize the order of all claims,
+ * or sort the claims by the property name (i.e., the placeholder claim
+   name for blinded claim names and the plaintext claim name for
+   unblinded claim names). The precise order does not matter. For
+   example, ordering by unicode code points or by lexicographic order is
+   sufficient to hide the original order of claims. 
+
+This applies to Issuers (SD-JWT and II-Disclosures document) and
+Holders (HS-Disclosures JWT).
 
 # Privacy Considerations {#privacy_considerations}
 

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -1712,7 +1712,9 @@ The following shows the user information used in this example, included a claim 
 }
 ```
 
-Hiding just this claim, the SD-JWT payload shown in the following would result. Note that the claims are sorted alphabetically as described in (#blinding-claim-names).
+Hiding just this claim, the SD-JWT payload shown in the following would
+result. Note that the claims are sorted (by the unicode code point
+numbers) as described in (#blinding-claim-names).
 
 {#example-simple_structured_some_blinded-sd_jwt_payload}
 ```json

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -1703,7 +1703,7 @@ Hiding just this claim, the SD-JWT payload shown in the following would result. 
 }
 ```
 
-In the II-Disclosures Object, it can be seen that the blinded claim's original name is `secret_club_membership_no`. Note again that the claims are sorted alphabetically as described in (#blinding-claim-names).
+In the II-Disclosures Object, it can be seen that the blinded claim's original name is `secret_club_membership_no`. Note that the claims are sorted alphabetically as described in (#blinding-claim-names).
 
 
 {#example-simple_structured_some_blinded-iid_payload}

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -541,13 +541,13 @@ be disclosed in full.
   "exp": 1516247022,
   "sd_digest_derivation_alg": "sha-256",
   "sd_digests": {
-    "sub": "OMdwkk2HPuiInPypWUWMxot1Y2tStGsLuIcDMjKdXMU",
-    "given_name": "AfKKH4a0IZki8MFDythFaFS_Xqzn-wRvAMfiy_VjYpE",
-    "family_name": "eUmXmry32JiK_76xMasagkAQQsmSVdW57Ajk18riSF0",
-    "email": "-Rcr4fDyjwlM_itcMxoQZCE1QAEwyLJcibEpH114KiE",
-    "phone_number": "Jv2nw0C1wP5ASutYNAxrWEnaDRIpiF0eTUAkUOp8F6Y",
-    "address": "ZrjKs-RmEAVeAYSzSw6GPFrMpcgctCfaJ6t9qQhbfJ4",
-    "birthdate": "qXPRRPdpNaebP8jtbEpO-skF4n7v7ASTh8oLg0mkAdQ"
+    "sub": "2EDXXZ1JcE6aTcM70fZopFneYAS9-hY3lalaoLuWD1s",
+    "given_name": "pC56LWpTgec18Ll1kps3koXapnw6SOiI0d1ba34t-mY",
+    "family_name": "EySQc316Ln3ZGJXwioELWSyylm_6OXV6rcL6LyPb7oI",
+    "email": "qHv6gGaq4oFmIXyKh9ZlFjQ5rOClS-dXHiPMZyl2FaU",
+    "phone_number": "jhr_PsauT4xsYZS_OxBW8y_1MLULOovKseRvF9CE0TM",
+    "address": "eQXgmowqkT_ORkedoqeW0wBUy4vzkWG1VhvOjh3tl_o",
+    "birthdate": "qgDxFuNpf83MkKe4GCaiLuL_XZdzO4pYD7lQKbv4zos"
   }
 }
 ```
@@ -571,21 +571,21 @@ xNzlNaEtHNVFvV19tVHoxMFFUXzZINGM3UGpXRzFmamg4aHBXTm5iUF9wdjZkMXpTd1pm
 YzVmbDZ5VlJMMERWMFYzbEdIS2UyV3FmX2VOR2pCckJMVmtsRFRrOC1zdFhfTVdMY1ItR
 UdtWEFPdjBVQldpdFNfZFhKS0p1LXZYSnl3MTRuSFNHdXhUSUsyaHgxcHR0TWZ0OUNzdn
 FpbVhLZURUVTE0cVFMMWVFN2loY3ciLCAiZSI6ICJBUUFCIn19LCAiaWF0IjogMTUxNjI
-zOTAyMiwgImV4cCI6IDE1MTYyNDcwMjIsICJzZF9oYXNoX2FsZyI6ICJzaGEtMjU2Iiwg
-InNkX2RpZ2VzdHMiOiB7InN1YiI6ICJPTWR3a2sySFB1aUluUHlwV1VXTXhvdDFZMnRTd
-EdzTHVJY0RNaktkWE1VIiwgImdpdmVuX25hbWUiOiAiQWZLS0g0YTBJWmtpOE1GRHl0aE
-ZhRlNfWHF6bi13UnZBTWZpeV9WallwRSIsICJmYW1pbHlfbmFtZSI6ICJlVW1YbXJ5MzJ
-KaUtfNzZ4TWFzYWdrQVFRc21TVmRXNTdBamsxOHJpU0YwIiwgImVtYWlsIjogIi1SY3I0
-ZkR5andsTV9pdGNNeG9RWkNFMVFBRXd5TEpjaWJFcEgxMTRLaUUiLCAicGhvbmVfbnVtY
-mVyIjogIkp2Mm53MEMxd1A1QVN1dFlOQXhyV0VuYURSSXBpRjBlVFVBa1VPcDhGNlkiLC
-AiYWRkcmVzcyI6ICJacmpLcy1SbUVBVmVBWVN6U3c2R1BGck1wY2djdENmYUo2dDlxUWh
-iZko0IiwgImJpcnRoZGF0ZSI6ICJxWFBSUlBkcE5hZWJQOGp0YkVwTy1za0Y0bjd2N0FT
-VGg4b0xnMG1rQWRRIn19.QgoJn9wkjFvM9bAr0hTDHLspuqdA21WzfBRVHkASa2ck4PFD
-3TC9MiZSi3AiRytRbYT4ZzvkH3BSbm6vy68y62gj0A6OYvZ1Z60Wxho14bxZQveJZgw3u
-_lMvYj6GKiUtskypFEHU-Kd-LoDVqEpf6lPQHdpsac__yQ_JL24oCEBlVQRXB-T-6ZNZf
-ID6JafSkNNCYQbI8nXbzIEp1LBFm0fE8eUd4G4yPYOj1SeuR6Gy92T0vAoL5QtpIAHo49
-oAmiSIj6DQNl2cNYs74jhrBIcNZyt4l8H1lV20wS5OS3T0vXaYD13fgm0p4iWD9cVg3HK
-ShUVulEyrSbq94jIKg
+zOTAyMiwgImV4cCI6IDE1MTYyNDcwMjIsICJzZF9kaWdlc3RfZGVyaXZhdGlvbl9hbGci
+OiAic2hhLTI1NiIsICJzZF9kaWdlc3RzIjogeyJzdWIiOiAiMkVEWFhaMUpjRTZhVGNNN
+zBmWm9wRm5lWUFTOS1oWTNsYWxhb0x1V0QxcyIsICJnaXZlbl9uYW1lIjogInBDNTZMV3
+BUZ2VjMThMbDFrcHMza29YYXBudzZTT2lJMGQxYmEzNHQtbVkiLCAiZmFtaWx5X25hbWU
+iOiAiRXlTUWMzMTZMbjNaR0pYd2lvRUxXU3l5bG1fNk9YVjZyY0w2THlQYjdvSSIsICJl
+bWFpbCI6ICJxSHY2Z0dhcTRvRm1JWHlLaDlabEZqUTVyT0NsUy1kWEhpUE1aeWwyRmFVI
+iwgInBob25lX251bWJlciI6ICJqaHJfUHNhdVQ0eHNZWlNfT3hCVzh5XzFNTFVMT292S3
+NlUnZGOUNFMFRNIiwgImFkZHJlc3MiOiAiZVFYZ21vd3FrVF9PUmtlZG9xZVcwd0JVeTR
+2emtXRzFWaHZPamgzdGxfbyIsICJiaXJ0aGRhdGUiOiAicWdEeEZ1TnBmODNNa0tlNEdD
+YWlMdUxfWFpkek80cFlEN2xRS2J2NHpvcyJ9fQ.0w8PQ_tg2K6Q82XhXn3-Nmi7uGeXkO
+FFMSfp_8iMKRRlfg-HXXdoZWv8UECv1B2PIJITjH2RAz_egYj-dLkPopnJ-0vIDKjKhvM
+CIIo0FEnTV3qQct-8s6NifR2exU1TuyF66Z9Jekk1V3M4BnKxCc6-mEf7_d1K-EfQ34dI
+-6XJFh05s1_sE7ePFvLRGtj4tHHQlwWGm7wQJqPRYtA_F0N10jIlyFbw4B6T59TpI8ZjH
+gucCxF9p1IUb-RYb6P1dYF4sVdQT258jAJVCAPz62JoRn-cPPwV-QbpAKD7npkk7pTxkY
+g0T9_iyvMcq_RdXGqqANkJn8qxEffwp_OsgA
 ```
 
 
@@ -609,24 +609,24 @@ private key.
 
 The II-Disclosures Object for Example 1 is as follows:
 
-{#example-simple-svc_payload}
+{#example-simple-iid_payload}
 ```json
 {
   "sd_ii_disclosures": {
-    "sub": "{\"s\": \"2GLC42sKQveCfGfryNRN9w\", \"v\":
+    "sub": "{\"s\": \"YZSmzeu7lFHUbZ8Z1QqH9Q\", \"v\":
       \"6c5c0a49-b589-431d-bae7-219122a9ec2c\"}",
-    "given_name": "{\"s\": \"6Ij7tM-a5iVPGboS5tmvVA\", \"v\":
+    "given_name": "{\"s\": \"kHHp91-tAZt8m9E4Jl4XbQ\", \"v\":
       \"John\"}",
-    "family_name": "{\"s\": \"Qg_O64zqAxe412a108iroA\", \"v\":
+    "family_name": "{\"s\": \"PjIqpGWl4eB4QroDhqQw0w\", \"v\":
       \"Doe\"}",
-    "email": "{\"s\": \"Pc33JM2LchcU_lHggv_ufQ\", \"v\":
+    "email": "{\"s\": \"QRamZSB5Ky0MeJyz4EAleA\", \"v\":
       \"johndoe@example.com\"}",
-    "phone_number": "{\"s\": \"lklxF5jMYlGTPUovMNIvCA\", \"v\":
+    "phone_number": "{\"s\": \"xniP4JZtNWIH-Lk_Dt-o-A\", \"v\":
       \"+1-202-555-0101\"}",
-    "address": "{\"s\": \"5bPs1IquZNa0hkaFzzzZNw\", \"v\":
+    "address": "{\"s\": \"KtfsxxTm2mw0YLUcKZU8tA\", \"v\":
       {\"street_address\": \"123 Main St\", \"locality\":
       \"Anytown\", \"region\": \"Anystate\", \"country\": \"US\"}}",
-    "birthdate": "{\"s\": \"y1sVU5wdfJahVdgwPgS7RQ\", \"v\":
+    "birthdate": "{\"s\": \"Ozd4wBLBwqGzJhJvTmQwdQ\", \"v\":
       \"1940-01-01\"}"
   }
 }
@@ -722,17 +722,17 @@ is not signed. TODO: Change to plain base64 to avoid alg=none issues
 
 The following is a non-normative example of the contents of a HS-Disclosures JWT for Example 1:
 
-{#example-simple-sd_jwt_release_payload}
+{#example-simple-hsd_jwt_payload}
 ```json
 {
   "nonce": "XZOUco1u_gEPknxS78sWWg",
   "aud": "https://example.com/verifier",
   "sd_hs_disclosures": {
-    "given_name": "{\"s\": \"6Ij7tM-a5iVPGboS5tmvVA\", \"v\":
+    "given_name": "{\"s\": \"kHHp91-tAZt8m9E4Jl4XbQ\", \"v\":
       \"John\"}",
-    "family_name": "{\"s\": \"Qg_O64zqAxe412a108iroA\", \"v\":
+    "family_name": "{\"s\": \"PjIqpGWl4eB4QroDhqQw0w\", \"v\":
       \"Doe\"}",
-    "address": "{\"s\": \"5bPs1IquZNa0hkaFzzzZNw\", \"v\":
+    "address": "{\"s\": \"KtfsxxTm2mw0YLUcKZU8tA\", \"v\":
       {\"street_address\": \"123 Main St\", \"locality\":
       \"Anytown\", \"region\": \"Anystate\", \"country\": \"US\"}}"
   }
@@ -933,7 +933,7 @@ revealed fundamental weaknesses and they MUST NOT be used.
 ## Holder Binding {#holder_binding_security}
 TBD
 
-## Blinding Claim Names
+## Blinding Claim Names {#blinding-claim-names}
 
 Issuers that chose to blind claim names MUST ensure not to inadvertently leak
 information about the blinded claim names to verifiers. In particular, issuers
@@ -942,10 +942,12 @@ MUST choose placeholder claim names accordingly.
 It is RECOMMENDED to use cryptographically salts with at least 128 bits
 of entropy as placeholder claim names.
 
-The order of elements in JSON-encoded objects is not relevant to applications,
-but the order may reveal information about the blinded claim name to the
-verifier. It is therefore RECOMMENDED to ensure that the order is shuffled or
-otherwise hidden (e.g., alphabetically ordered using the blinded claim names).
+The order of elements in JSON-encoded objects is not relevant to
+applications, but the order may reveal information about the blinded
+claim name to the verifier. It is therefore RECOMMENDED to ensure that
+the claims in the SD-JWT, II-Disclosures object, and HS-Disclosures JWT
+is shuffled or otherwise hidden, e.g., by alphabetically sorting using
+the blinded claim names.
 
 # Privacy Considerations {#privacy_considerations}
 
@@ -1070,49 +1072,49 @@ allows for the disclosure of individual members of the address claim separately.
   "exp": 1516247022,
   "sd_digest_derivation_alg": "sha-256",
   "sd_digests": {
-    "sub": "OMdwkk2HPuiInPypWUWMxot1Y2tStGsLuIcDMjKdXMU",
-    "given_name": "AfKKH4a0IZki8MFDythFaFS_Xqzn-wRvAMfiy_VjYpE",
-    "family_name": "eUmXmry32JiK_76xMasagkAQQsmSVdW57Ajk18riSF0",
-    "email": "-Rcr4fDyjwlM_itcMxoQZCE1QAEwyLJcibEpH114KiE",
-    "phone_number": "Jv2nw0C1wP5ASutYNAxrWEnaDRIpiF0eTUAkUOp8F6Y",
+    "sub": "p7GDm8_lnxCJUsQojBatCJQgPCZOVBGxU-eX_lUIcC4",
+    "given_name": "BrmUer7nGIRyk3sbHHcZk43M9Oy_BQar0VE3NMOGk9w",
+    "family_name": "8voOnlh20GGzTInd6T9-Vcu2l6Q4_Kc-keedo7_3VY8",
+    "email": "b9DpmK8_xwhR4PX_MiIsQc1TyB_1NN40lI5Kj8SSNl4",
+    "phone_number": "0LFRbHdtG1eze9ET1rDEtSIrPI0poCM3J0EYBt2iwVg",
     "address": {
       "street_address":
-        "n25N6kth9N0CwjZXHeth1gfovg8_I8fGyzeY0qeLp0k",
-      "locality": "gJVL_TKoT_SbA4_sv0klLTkg-YEGzVUkC-6egxegsz0",
-      "region": "zXbstGPuPq2cPJfyD_-HlmqVyFMf03xH-FbeotXxdbo",
-      "country": "pN-5CZ5hbumsPvLKUADm4Ott6gu0E4xj09s4Z51yb8U"
+        "qYDFWJxdl_OQDdn_lxX1-E9r5H2juwqonoWM8A76X_w",
+      "locality": "3mLauig0JJyjJbdMvf3jLJGSBAIt0tdvq7F_VL1gqXw",
+      "region": "qRa_XKvVxCzUK8buAsxg9ylzyQlfvUgSwqATQV74z6c",
+      "country": "DjbYtjTT3PAQHtVkcpvrnRboYVUfXMro6Y4oEGdHW_0"
     },
-    "birthdate": "UxsvgkUgPnawP6wY4hmxJ_jqiNNKni62zrX7hQOUsys"
+    "birthdate": "rXv8RpBXYOy9WtYf2Bg-KIdO0a3KnYGCAhL53iCsLJA"
   }
 }
 ```
 
 The II-Disclosures Object for this SD-JWT is as follows:
 
-{#example-simple_structured-svc_payload}
+{#example-simple_structured-iid_payload}
 ```json
 {
   "sd_ii_disclosures": {
-    "sub": "{\"s\": \"2GLC42sKQveCfGfryNRN9w\", \"v\":
+    "sub": "{\"s\": \"2iFrkb5skOft_gSL6BhdBg\", \"v\":
       \"6c5c0a49-b589-431d-bae7-219122a9ec2c\"}",
-    "given_name": "{\"s\": \"6Ij7tM-a5iVPGboS5tmvVA\", \"v\":
+    "given_name": "{\"s\": \"AbA1MKJ1Oyqtff2JoFKNXA\", \"v\":
       \"John\"}",
-    "family_name": "{\"s\": \"Qg_O64zqAxe412a108iroA\", \"v\":
+    "family_name": "{\"s\": \"vGk9hg40yrI1qazJn8qaKw\", \"v\":
       \"Doe\"}",
-    "email": "{\"s\": \"Pc33JM2LchcU_lHggv_ufQ\", \"v\":
+    "email": "{\"s\": \"6Ilb1QXTN4Qdv-1qGcQdbw\", \"v\":
       \"johndoe@example.com\"}",
-    "phone_number": "{\"s\": \"lklxF5jMYlGTPUovMNIvCA\", \"v\":
+    "phone_number": "{\"s\": \"-F5a6ZAOKHwUsYPDS383pQ\", \"v\":
       \"+1-202-555-0101\"}",
     "address": {
-      "street_address": "{\"s\": \"5bPs1IquZNa0hkaFzzzZNw\", \"v\":
+      "street_address": "{\"s\": \"t6GqrdbiTFbJYh4D38aLjA\", \"v\":
         \"123 Main St\"}",
-      "locality": "{\"s\": \"y1sVU5wdfJahVdgwPgS7RQ\", \"v\":
+      "locality": "{\"s\": \"B0G5ap7hsAPIYOJ21rUjgg\", \"v\":
         \"Anytown\"}",
-      "region": "{\"s\": \"C9GSoujviJquEgYfojCb1A\", \"v\":
+      "region": "{\"s\": \"YTPF0rUHYtvldv1Df63WXQ\", \"v\":
         \"Anystate\"}",
-      "country": "{\"s\": \"H3o1uswP760Fi2yeGdVCEQ\", \"v\": \"US\"}"
+      "country": "{\"s\": \"mVZ4hCTnVdpu_GN-Rb9wNw\", \"v\": \"US\"}"
     },
-    "birthdate": "{\"s\": \"M0Jb57t41ubrkSuyrDT3xA\", \"v\":
+    "birthdate": "{\"s\": \"T6-5A3xYsyy2MnwnUWbW3w\", \"v\":
       \"1940-01-01\"}"
   }
 }
@@ -1121,22 +1123,22 @@ The II-Disclosures Object for this SD-JWT is as follows:
 a HS-Disclosures JWT for the SD-JWT above that discloses only `region` and `country` of
 the `address` property:
 
-{#example-simple_structured-sd_jwt_release_payload}
+{#example-simple_structured-hsd_jwt_payload}
 ```json
 {
   "nonce": "XZOUco1u_gEPknxS78sWWg",
   "aud": "https://example.com/verifier",
   "sd_hs_disclosures": {
-    "given_name": "{\"s\": \"6Ij7tM-a5iVPGboS5tmvVA\", \"v\":
+    "given_name": "{\"s\": \"AbA1MKJ1Oyqtff2JoFKNXA\", \"v\":
       \"John\"}",
-    "family_name": "{\"s\": \"Qg_O64zqAxe412a108iroA\", \"v\":
+    "family_name": "{\"s\": \"vGk9hg40yrI1qazJn8qaKw\", \"v\":
       \"Doe\"}",
-    "birthdate": "{\"s\": \"M0Jb57t41ubrkSuyrDT3xA\", \"v\":
+    "birthdate": "{\"s\": \"T6-5A3xYsyy2MnwnUWbW3w\", \"v\":
       \"1940-01-01\"}",
     "address": {
-      "region": "{\"s\": \"C9GSoujviJquEgYfojCb1A\", \"v\":
+      "region": "{\"s\": \"YTPF0rUHYtvldv1Df63WXQ\", \"v\":
         \"Anystate\"}",
-      "country": "{\"s\": \"H3o1uswP760Fi2yeGdVCEQ\", \"v\": \"US\"}"
+      "country": "{\"s\": \"mVZ4hCTnVdpu_GN-Rb9wNw\", \"v\": \"US\"}"
     }
   }
 }
@@ -1173,19 +1175,19 @@ The JSON-payload of the SD-JWT that contains both selectively disclosable claims
   "exp": 1516247022,
   "sd_digest_derivation_alg": "sha-256",
   "sd_digests": {
-    "sub": "OMdwkk2HPuiInPypWUWMxot1Y2tStGsLuIcDMjKdXMU",
-    "given_name": "AfKKH4a0IZki8MFDythFaFS_Xqzn-wRvAMfiy_VjYpE",
-    "family_name": "eUmXmry32JiK_76xMasagkAQQsmSVdW57Ajk18riSF0",
-    "email": "-Rcr4fDyjwlM_itcMxoQZCE1QAEwyLJcibEpH114KiE",
-    "phone_number": "Jv2nw0C1wP5ASutYNAxrWEnaDRIpiF0eTUAkUOp8F6Y",
+    "sub": "7HAA9WvPAYvzu3hN6OtEiGJ2du77SjwJiF6JvtbeMuU",
+    "given_name": "la2htSV8whimWwbio5b05g3lsRA12jNEPAc9_HYDHy0",
+    "family_name": "BpXbL49wAWVasBpaHF3JUwHwOa8VjvigCPaACogeR04",
+    "email": "XrhKROmHRUGtIZ-dcBxGc63stu3xMLD3FJPRfJ98wzI",
+    "phone_number": "rZBPJA86d2xPhDpSKwmlCzmtqiKPSySrV35Fn5t4HCU",
     "address": {
       "street_address":
-        "n25N6kth9N0CwjZXHeth1gfovg8_I8fGyzeY0qeLp0k",
-      "locality": "gJVL_TKoT_SbA4_sv0klLTkg-YEGzVUkC-6egxegsz0",
-      "region": "zXbstGPuPq2cPJfyD_-HlmqVyFMf03xH-FbeotXxdbo",
-      "country": "pN-5CZ5hbumsPvLKUADm4Ott6gu0E4xj09s4Z51yb8U"
+        "xnnXv6CdbA7W32QFVR7EJR8HUSPve-BctZB8fQeQY3w",
+      "locality": "oTEeEDiZ_w6RieLd-upFz3uAjhmbt_PJWCB2SmQqch8",
+      "region": "IQI47wPHBkSQ6SGQrbAeCc-YfvfCtrKzOXEf76Un-JI",
+      "country": "A6uzBmWsTYOHryTvu525qMsye0KjL7Ana1JAfIRqLjQ"
     },
-    "birthdate": "UxsvgkUgPnawP6wY4hmxJ_jqiNNKni62zrX7hQOUsys"
+    "birthdate": "3CT30sE4eEQH5QFeZvkUmwphHrnEwrY1DVkQ1BAIr7E"
   },
   "address": {
     "country": "US"
@@ -1196,24 +1198,24 @@ The JSON-payload of the SD-JWT that contains both selectively disclosable claims
 The holder can now, for example, release the rest of the components of the `address` claim in the HS-Disclosures:
 
 
-{#example-simple_structured_merging-sd_jwt_release_payload}
+{#example-simple_structured_merging-hsd_jwt_payload}
 ```json
 {
   "nonce": "XZOUco1u_gEPknxS78sWWg",
   "aud": "https://example.com/verifier",
   "sd_hs_disclosures": {
-    "given_name": "{\"s\": \"6Ij7tM-a5iVPGboS5tmvVA\", \"v\":
+    "given_name": "{\"s\": \"44PE8SYm3Mg7kqxua_ftyw\", \"v\":
       \"John\"}",
-    "family_name": "{\"s\": \"Qg_O64zqAxe412a108iroA\", \"v\":
+    "family_name": "{\"s\": \"DBcSkeRQqVkPfTyNNWSkbA\", \"v\":
       \"Doe\"}",
-    "birthdate": "{\"s\": \"M0Jb57t41ubrkSuyrDT3xA\", \"v\":
+    "birthdate": "{\"s\": \"nIiX9JVD9JYCPBlYcIrukA\", \"v\":
       \"1940-01-01\"}",
     "address": {
-      "region": "{\"s\": \"C9GSoujviJquEgYfojCb1A\", \"v\":
+      "region": "{\"s\": \"XtnSYJPrsh_ShvklQhbDgQ\", \"v\":
         \"Anystate\"}",
-      "street_address": "{\"s\": \"5bPs1IquZNa0hkaFzzzZNw\", \"v\":
+      "street_address": "{\"s\": \"hP_dhW14jiTijaQZOOFvUw\", \"v\":
         \"123 Main St\"}",
-      "locality": "{\"s\": \"y1sVU5wdfJahVdgwPgS7RQ\", \"v\":
+      "locality": "{\"s\": \"9678ZRsZ5nwcWmU_wIqKFg\", \"v\":
         \"Anytown\"}"
     }
   }
@@ -1333,52 +1335,52 @@ The issuer in this example further adds the two claims `birthdate` and `place_of
     "verified_claims": {
       "verification": {
         "trust_framework":
-          "T7ivxsfuy-nAuECeh0utPEX8cSlc7QflJDE0RqtWDMU",
-        "time": "_ecCQoXSR8t9esur66ZwWwC6u4xLuVELjmwFgpRZqcQ",
+          "fkIW-4iUZgTeIeDg_Z_6oFHU-wyWwazSpuaiQbc5QKw",
+        "time": "VRF-G_LfTzSaYkLelVzry82l1zQxGwk1RfGcnUUWukc",
         "verification_process":
-          "BolwKKvU8N7uUhjN2aGH2T54wjXpkcOz5sC9PkIP4s4",
+          "9OpDml4eRBM6Usfk3MF2i7kBl1xGGkzPq5Ncs1mvbPo",
         "evidence": [
           {
-            "type": "7jBlUZkZn1Gfj9mybqlJGzTb2z8KcNNHU0IV4B8MxOM",
-            "method": "BRQgcT09gdBqO-MLTka8d6dlCshZCUNpFgsZoet5I-o",
-            "time": "-PVLNSmbkCHLp8S7i077YnHZV0yE8gyKWLpWV2o8FJE",
+            "type": "HucanHhQwb-TJNg_rVpaonNSDtzPrCEebb3LfXTuLSM",
+            "method": "aU7IO7ooT8vArMkqpOfkIAlKw8BNcfRyw3NXs3ZS128",
+            "time": "LHcH98bV3-ZNUa00HNnqOf8W5IdijY1aEnpVzDNVBwA",
             "document": {
-              "type": "vzDHD-6hQqZ5lSw_7acK1lErxSh3E6dO0zlUYM2hDvw",
+              "type": "3ITIlfkbUI0NveviEJBw-_VEaGiPtCDcXy9uD9orWFA",
               "issuer": {
                 "name":
-                  "us9T9ufVdSmytSmjrtdN_TUI0ai3_JNM3q-0qx0CXk4",
+                  "AY7wW63Vbcd7RnKDb39sSXpLgyiVNxWgoRnV6xZD5C8",
                 "country":
-                  "uItKtPRZQBB9v5THHOdi02ALjD0MH0U6jjHDLe91NnY"
+                  "Kd3aUmm6XHjpWp6OYiJeEZUrD5J7nIRU3SlTc-E53gs"
               },
               "number":
-                "QNNXwo3siOWdqNivKBnFsD4X8gZxVIgu3tv6dfpZhUc",
+                "8gKpksl66fN9F2Zxs1PRPgD8kHi8dGC2JzpqtrPZavs",
               "date_of_issuance":
-                "AYWQphnOlFFN9oSVvtBr_iYCKYlucTi3lsMrXebebgc",
+                "GfIEhOGWwe8J7lx6HSAPpC-Qvx0ihwWkEE0_LZ-r_DI",
               "date_of_expiry":
-                "JIk-APYHW3qy60rvGyFswDCTMfAbBXZyyrZEn8NsBhU"
+                "_fdljKRdp5wptGi7DwKNZEsSX6AnniVqmDE0aSznH74"
             }
           }
         ]
       },
       "claims": {
-        "given_name": "hZtT6FZBzxAeByDUkFJTeqTCpTd2cQKx6MDPkGvVCRE",
-        "family_name": "5yLYGVxPSfXynhcopbIcrFe0_sMGxv_-6THZAu4eWnU",
+        "given_name": "sx4wGd6-ONAsiq7dN16GHeg4RAyOshRBdoXWE_E751w",
+        "family_name": "Ldbea0SibAQDiZJlBigptwWXZ9QA8a0dKK7jipSn2K8",
         "nationalities":
-          "BxCtneHl-RQoL24tS8AaywfyHpnZSq9tUsNDyrYFLYY",
+          "tr8SXHdYS0rzAio_IhFp2lzlta4kDzKCM7hUxItCU2U",
         "address": {
-          "locality": "ah6QI8ceduHKP7uiHbwZ2a2LYkxjibHaoWG3M6x1ip4",
+          "locality": "VFgKHPXnNrZHeoBwcu61b5VCoFVX0rQjtH5aOiiLz0E",
           "postal_code":
-            "Auci5Y0jrp_3ahg_IW_Z-mqBaE9BrrItR6o7ekhEGBo",
-          "country": "RAKTJg_m1tcoyGI1O2qgQm4KD2d2abXhU4IS7c6RVjU",
+            "G8XHi8sCPc45WATery6RSvnEcdypnrjypjBl4LBd5YE",
+          "country": "YyG4Nhyfjitpo6-yMDRTARSVAnZNvkYqRY3XepoQ_j8",
           "street_address":
-            "iKkk1nJHTBKTkEt2TNMkZf69WYkiDYaQL6ZzDZmGO1M"
+            "NwAKfAtjQcN_XbV3kuHt3gbUMvQ83n02C1EexI9Ro2A"
         }
       }
     },
     "birth_middle_name":
-      "KpRjGCm3uykvCGFIDrVJ7iTMQhWakBmCItHbAa6vnZE",
-    "salutation": "IoY5e03e65CUrnaMcRDmPCm0RWPEFE4mVkoCsK86agA",
-    "msisdn": "XupJick4P8bxaz20kx_VOwbGU1cgslhAUG6IE-tDjms"
+      "M5GhkvNcGjGONRey2pRORuL2yCfYz5jo0XqF6K0tUWk",
+    "salutation": "8m0-sBNA8I88_LDc05C7gE31pTm_CXQfewiwlL1Sn1Y",
+    "msisdn": "dLQVMDIkEHnmPVvuHNYiv7WwAqGE7mbyJMh5EfbjM1Q"
   },
   "verified_claims": {
     "claims": {
@@ -1406,48 +1408,48 @@ xNzlNaEtHNVFvV19tVHoxMFFUXzZINGM3UGpXRzFmamg4aHBXTm5iUF9wdjZkMXpTd1pm
 YzVmbDZ5VlJMMERWMFYzbEdIS2UyV3FmX2VOR2pCckJMVmtsRFRrOC1zdFhfTVdMY1ItR
 UdtWEFPdjBVQldpdFNfZFhKS0p1LXZYSnl3MTRuSFNHdXhUSUsyaHgxcHR0TWZ0OUNzdn
 FpbVhLZURUVTE0cVFMMWVFN2loY3ciLCAiZSI6ICJBUUFCIn19LCAiaWF0IjogMTUxNjI
-zOTAyMiwgImV4cCI6IDE1MTYyNDcwMjIsICJzZF9oYXNoX2FsZyI6ICJzaGEtMjU2Iiwg
-InNkX2RpZ2VzdHMiOiB7InZlcmlmaWVkX2NsYWltcyI6IHsidmVyaWZpY2F0aW9uIjoge
-yJ0cnVzdF9mcmFtZXdvcmsiOiAiVDdpdnhzZnV5LW5BdUVDZWgwdXRQRVg4Y1NsYzdRZm
-xKREUwUnF0V0RNVSIsICJ0aW1lIjogIl9lY0NRb1hTUjh0OWVzdXI2Nlp3V3dDNnU0eEx
-1VkVMam13RmdwUlpxY1EiLCAidmVyaWZpY2F0aW9uX3Byb2Nlc3MiOiAiQm9sd0tLdlU4
-Tjd1VWhqTjJhR0gyVDU0d2pYcGtjT3o1c0M5UGtJUDRzNCIsICJldmlkZW5jZSI6IFt7I
-nR5cGUiOiAiN2pCbFVaa1puMUdmajlteWJxbEpHelRiMno4S2NOTkhVMElWNEI4TXhPTS
-IsICJtZXRob2QiOiAiQlJRZ2NUMDlnZEJxTy1NTFRrYThkNmRsQ3NoWkNVTnBGZ3Nab2V
-0NUktbyIsICJ0aW1lIjogIi1QVkxOU21ia0NITHA4UzdpMDc3WW5IWlYweUU4Z3lLV0xw
-V1YybzhGSkUiLCAiZG9jdW1lbnQiOiB7InR5cGUiOiAidnpESEQtNmhRcVo1bFN3XzdhY
-0sxbEVyeFNoM0U2ZE8wemxVWU0yaER2dyIsICJpc3N1ZXIiOiB7Im5hbWUiOiAidXM5VD
-l1ZlZkU215dFNtanJ0ZE5fVFVJMGFpM19KTk0zcS0wcXgwQ1hrNCIsICJjb3VudHJ5Ijo
-gInVJdEt0UFJaUUJCOXY1VEhIT2RpMDJBTGpEME1IMFU2ampIRExlOTFOblkifSwgIm51
-bWJlciI6ICJRTk5Yd28zc2lPV2RxTml2S0JuRnNENFg4Z1p4VklndTN0djZkZnBaaFVjI
-iwgImRhdGVfb2ZfaXNzdWFuY2UiOiAiQVlXUXBobk9sRkZOOW9TVnZ0QnJfaVlDS1lsdW
-NUaTNsc01yWGViZWJnYyIsICJkYXRlX29mX2V4cGlyeSI6ICJKSWstQVBZSFczcXk2MHJ
-2R3lGc3dEQ1RNZkFiQlhaeXlyWkVuOE5zQmhVIn19XX0sICJjbGFpbXMiOiB7ImdpdmVu
-X25hbWUiOiAiaFp0VDZGWkJ6eEFlQnlEVWtGSlRlcVRDcFRkMmNRS3g2TURQa0d2VkNSR
-SIsICJmYW1pbHlfbmFtZSI6ICI1eUxZR1Z4UFNmWHluaGNvcGJJY3JGZTBfc01HeHZfLT
-ZUSFpBdTRlV25VIiwgIm5hdGlvbmFsaXRpZXMiOiAiQnhDdG5lSGwtUlFvTDI0dFM4QWF
-5d2Z5SHBuWlNxOXRVc05EeXJZRkxZWSIsICJhZGRyZXNzIjogeyJsb2NhbGl0eSI6ICJh
-aDZRSThjZWR1SEtQN3VpSGJ3WjJhMkxZa3hqaWJIYW9XRzNNNngxaXA0IiwgInBvc3Rhb
-F9jb2RlIjogIkF1Y2k1WTBqcnBfM2FoZ19JV19aLW1xQmFFOUJyckl0UjZvN2VraEVHQm
-8iLCAiY291bnRyeSI6ICJSQUtUSmdfbTF0Y295R0kxTzJxZ1FtNEtEMmQyYWJYaFU0SVM
-3YzZSVmpVIiwgInN0cmVldF9hZGRyZXNzIjogImlLa2sxbkpIVEJLVGtFdDJUTk1rWmY2
-OVdZa2lEWWFRTDZaekRabUdPMU0ifX19LCAiYmlydGhfbWlkZGxlX25hbWUiOiAiS3BSa
-kdDbTN1eWt2Q0dGSURyVko3aVRNUWhXYWtCbUNJdEhiQWE2dm5aRSIsICJzYWx1dGF0aW
-9uIjogIklvWTVlMDNlNjVDVXJuYU1jUkRtUENtMFJXUEVGRTRtVmtvQ3NLODZhZ0EiLCA
-ibXNpc2RuIjogIlh1cEppY2s0UDhieGF6MjBreF9WT3diR1UxY2dzbGhBVUc2SUUtdERq
-bXMifSwgInZlcmlmaWVkX2NsYWltcyI6IHsiY2xhaW1zIjogeyJiaXJ0aGRhdGUiOiAiM
-Tk1Ni0wMS0yOCIsICJwbGFjZV9vZl9iaXJ0aCI6IHsiY291bnRyeSI6ICJERSIsICJsb2
-NhbGl0eSI6ICJNdXN0ZXJzdGFkdCJ9fX19.h3d682fP_x2tqYiUR4y2ftsWE8DHOyg0VF
-Y4q9jUAH7yCk7KExyDUBaiyLrFhgFmJHWzkFoggcSTLsvOAM1QB7kgOilwNW8KKtZpSQV
-2Db7WEmXi-Q2QblSNGVNXAcZMobLnl6j4QJJaW-5xLbH-6S1Fe2Vw2hn3rQ2VLzPTUZjz
-CWk3OdLWTI5MlaYr9GleK9ZDErlrCXtfsXRY6M-Smvb8ZvIDs95vGxsJW-6SbasuonTun
-zZGdt2WqXFRtXuaCb-Vw9wPXuytHmH_1vuyROhH8ITzqYbTZ-4H6eS5BLjx8HXWQDk3r-
-M_g9htP9G3ezhDi3uzLQ2dSAbNqOWiXQ
+zOTAyMiwgImV4cCI6IDE1MTYyNDcwMjIsICJzZF9kaWdlc3RfZGVyaXZhdGlvbl9hbGci
+OiAic2hhLTI1NiIsICJzZF9kaWdlc3RzIjogeyJ2ZXJpZmllZF9jbGFpbXMiOiB7InZlc
+mlmaWNhdGlvbiI6IHsidHJ1c3RfZnJhbWV3b3JrIjogImZrSVctNGlVWmdUZUllRGdfWl
+82b0ZIVS13eVd3YXpTcHVhaVFiYzVRS3ciLCAidGltZSI6ICJWUkYtR19MZlR6U2FZa0x
+lbFZ6cnk4MmwxelF4R3drMVJmR2NuVVVXdWtjIiwgInZlcmlmaWNhdGlvbl9wcm9jZXNz
+IjogIjlPcERtbDRlUkJNNlVzZmszTUYyaTdrQmwxeEdHa3pQcTVOY3MxbXZiUG8iLCAiZ
+XZpZGVuY2UiOiBbeyJ0eXBlIjogIkh1Y2FuSGhRd2ItVEpOZ19yVnBhb25OU0R0elByQ0
+VlYmIzTGZYVHVMU00iLCAibWV0aG9kIjogImFVN0lPN29vVDh2QXJNa3FwT2ZrSUFsS3c
+4Qk5jZlJ5dzNOWHMzWlMxMjgiLCAidGltZSI6ICJMSGNIOThiVjMtWk5VYTAwSE5ucU9m
+OFc1SWRpalkxYUVucFZ6RE5WQndBIiwgImRvY3VtZW50IjogeyJ0eXBlIjogIjNJVElsZ
+mtiVUkwTnZldmlFSkJ3LV9WRWFHaVB0Q0RjWHk5dUQ5b3JXRkEiLCAiaXNzdWVyIjogey
+JuYW1lIjogIkFZN3dXNjNWYmNkN1JuS0RiMzlzU1hwTGd5aVZOeFdnb1JuVjZ4WkQ1Qzg
+iLCAiY291bnRyeSI6ICJLZDNhVW1tNlhIanBXcDZPWWlKZUVaVXJENUo3bklSVTNTbFRj
+LUU1M2dzIn0sICJudW1iZXIiOiAiOGdLcGtzbDY2Zk45RjJaeHMxUFJQZ0Q4a0hpOGRHQ
+zJKenBxdHJQWmF2cyIsICJkYXRlX29mX2lzc3VhbmNlIjogIkdmSUVoT0dXd2U4SjdseD
+ZIU0FQcEMtUXZ4MGlod1drRUUwX0xaLXJfREkiLCAiZGF0ZV9vZl9leHBpcnkiOiAiX2Z
+kbGpLUmRwNXdwdEdpN0R3S05aRXNTWDZBbm5pVnFtREUwYVN6bkg3NCJ9fV19LCAiY2xh
+aW1zIjogeyJnaXZlbl9uYW1lIjogInN4NHdHZDYtT05Bc2lxN2ROMTZHSGVnNFJBeU9za
+FJCZG9YV0VfRTc1MXciLCAiZmFtaWx5X25hbWUiOiAiTGRiZWEwU2liQVFEaVpKbEJpZ3
+B0d1dYWjlRQThhMGRLSzdqaXBTbjJLOCIsICJuYXRpb25hbGl0aWVzIjogInRyOFNYSGR
+ZUzByekFpb19JaEZwMmx6bHRhNGtEektDTTdoVXhJdENVMlUiLCAiYWRkcmVzcyI6IHsi
+bG9jYWxpdHkiOiAiVkZnS0hQWG5OclpIZW9Cd2N1NjFiNVZDb0ZWWDByUWp0SDVhT2lpT
+HowRSIsICJwb3N0YWxfY29kZSI6ICJHOFhIaThzQ1BjNDVXQVRlcnk2UlN2bkVjZHlwbn
+JqeXBqQmw0TEJkNVlFIiwgImNvdW50cnkiOiAiWXlHNE5oeWZqaXRwbzYteU1EUlRBUlN
+WQW5aTnZrWXFSWTNYZXBvUV9qOCIsICJzdHJlZXRfYWRkcmVzcyI6ICJOd0FLZkF0alFj
+Tl9YYlYza3VIdDNnYlVNdlE4M24wMkMxRWV4STlSbzJBIn19fSwgImJpcnRoX21pZGRsZ
+V9uYW1lIjogIk01R2hrdk5jR2pHT05SZXkycFJPUnVMMnlDZll6NWpvMFhxRjZLMHRVV2
+siLCAic2FsdXRhdGlvbiI6ICI4bTAtc0JOQThJODhfTERjMDVDN2dFMzFwVG1fQ1hRZmV
+3aXdsTDFTbjFZIiwgIm1zaXNkbiI6ICJkTFFWTURJa0VIbm1QVnZ1SE5ZaXY3V3dBcUdF
+N21ieUpNaDVFZmJqTTFRIn0sICJ2ZXJpZmllZF9jbGFpbXMiOiB7ImNsYWltcyI6IHsiY
+mlydGhkYXRlIjogIjE5NTYtMDEtMjgiLCAicGxhY2Vfb2ZfYmlydGgiOiB7ImNvdW50cn
+kiOiAiREUiLCAibG9jYWxpdHkiOiAiTXVzdGVyc3RhZHQifX19fQ.57pncJcJ6cQt2fSA
+RbQLlj6e6nYMpWqHNvI2Ep45WmNGuTtI3htmodK8svpgbrT-RaLL25WF7J3CqP1ElzpZS
+gVFs2VXCxGXgnTG6dQIvk2qPPfP-45hrZiMWyiwRFBr7Di68J01N90yFGbsMH5hh8kGGq
+FnCpTSQwvk--6aG_03l0nGmLDjOFyauCF_Tl-SlOHzNGYoP3MOOX9jU25T8z2e3EmLVLT
+a5KEmNis0GbpfSHUthbtZCCTaq-bSYaPDUHi22ZNqeoW1Y4v8nSaNIyrV9IxfPJNb37kY
+N6NLn5zwI33sxE_nCd8wOxvuI0rtFtmpS_-DNgwPTnLphzUNKA
 ```
 
 A HS-Disclosures JWT for some of the claims may look as follows:
 
-{#example-complex-sd_jwt_release_payload}
+{#example-complex-hsd_jwt_payload}
 ```json
 {
   "nonce": "XZOUco1u_gEPknxS78sWWg",
@@ -1455,21 +1457,21 @@ A HS-Disclosures JWT for some of the claims may look as follows:
   "sd_hs_disclosures": {
     "verified_claims": {
       "verification": {
-        "trust_framework": "{\"s\": \"2GLC42sKQveCfGfryNRN9w\",
+        "trust_framework": "{\"s\": \"SJKr-Pydh8RqHomXCOiVwQ\",
           \"v\": \"de_aml\"}",
-        "time": "{\"s\": \"6Ij7tM-a5iVPGboS5tmvVA\", \"v\":
+        "time": "{\"s\": \"CrxH2Ez8uu2t7tEPQqwZig\", \"v\":
           \"2012-04-23T18:25Z\"}",
         "evidence": [
           {
-            "type": "{\"s\": \"Pc33JM2LchcU_lHggv_ufQ\", \"v\":
+            "type": "{\"s\": \"sPCCbZtOdjnQjfOiPBxOYA\", \"v\":
               \"document\"}"
           }
         ]
       },
       "claims": {
-        "given_name": "{\"s\": \"4KyR32oIZt-zkWvFqbULKg\", \"v\":
+        "given_name": "{\"s\": \"kqwnbB6oHhaBD3F3t-KUGw\", \"v\":
           \"Max\"}",
-        "family_name": "{\"s\": \"flNP1ncMz9Lg-c9qMIz_9g\", \"v\":
+        "family_name": "{\"s\": \"_6Do5glcgEQDMVJoPArGSA\", \"v\":
           \"Meier\"}"
       }
     }
@@ -1659,105 +1661,105 @@ The following shows the user information used in this example, included a claim 
 }
 ```
 
-Hiding just this claim, the following SD-JWT payload would result:
+Hiding just this claim, the SD-JWT payload shown in the following would result. Note that the claims are sorted alphabetically as described in (#blinding-claim-names).
 
 {#example-simple_structured_some_blinded-sd_jwt_payload}
 ```json
 {
-  "iss": "https://example.com/issuer",
   "cnf": {
     "jwk": {
+      "e": "AQAB",
       "kty": "RSA",
       "n": "pm4bOHBg-oYhAyPWzR56AWX3rUIXp11_ICDkGgS6W3ZWLts-hzwI3x656
         59kg4hVo9dbGoCJE3ZGF_eaetE30UhBUEgpGwrDrQiJ9zqprmcFfr3qvvkGjt
         th8Zgl1eM2bJcOwE7PCBHWTKWYs152R7g6Jg2OVph-a8rq-q79MhKG5QoW_mT
         z10QT_6H4c7PjWG1fjh8hpWNnbP_pv6d1zSwZfc5fl6yVRL0DV0V3lGHKe2Wq
         f_eNGjBrBLVklDTk8-stX_MWLcR-EGmXAOv0UBWitS_dXJKJu-vXJyw14nHSG
-        uxTIK2hx1pttMft9CsvqimXKeDTU14qQL1eE7ihcw",
-      "e": "AQAB"
+        uxTIK2hx1pttMft9CsvqimXKeDTU14qQL1eE7ihcw"
     }
   },
-  "iat": 1516239022,
   "exp": 1516247022,
+  "iat": 1516239022,
+  "iss": "https://example.com/issuer",
   "sd_digest_derivation_alg": "sha-256",
   "sd_digests": {
-    "sub": "OMdwkk2HPuiInPypWUWMxot1Y2tStGsLuIcDMjKdXMU",
-    "given_name": "AfKKH4a0IZki8MFDythFaFS_Xqzn-wRvAMfiy_VjYpE",
-    "family_name": "eUmXmry32JiK_76xMasagkAQQsmSVdW57Ajk18riSF0",
-    "email": "-Rcr4fDyjwlM_itcMxoQZCE1QAEwyLJcibEpH114KiE",
-    "phone_number": "Jv2nw0C1wP5ASutYNAxrWEnaDRIpiF0eTUAkUOp8F6Y",
-    "5a2W0_NrlEZzfqmk_7Pq-w":
-      "gc8VzGTImYRXzP6j7q5RomXt2C_wtsOJ3hAHJdTuEIY",
-    "other_secret_club_membership_no":
-      "IirAwgN-MubteYvJ4fmq04p9PnpRTf7hqg0dzSWRboA",
+    "HS4QoeE9ty-I8BZTEupSzw":
+      "emp2qhunGPulOGvtgor5dFwNSasDewLqNdqXCkYl4Nw",
     "address": {
-      "street_address":
-        "o_yJIdfhKuKVzOF7i1EuakzC5ghd99CX8_nitm-DsRM",
-      "locality": "ogNqsvRqK0-ZPZc9C3Z4_6APvywm-lrm0oF2gcVtl_4",
-      "region": "8kFihRLSkEheK0zbEsQ3zKXt8csE6OXJE_jv3032BbU",
-      "country": "11IMcoA18LrFSpbysx-uqe7N3I3-QZKwCJqYeQuOUY4"
+      "country": "Bktf3gG1tXbn0XObrZT53RUr_lxMLZGEguLYwCvsaIg",
+      "locality": "NeWRh4B9JLRfEODwno3UOXg9Pg3gtZEo45cK9pr4eZk",
+      "region": "qpgFbdX1Az4Hm_E63K3J94oMzazHLCqqFb0Damo2eFE",
+      "street_address": "6Ex8b2gEeACuMal74_OBH_ROVNM7wvzjSck08EC9eSs"
     },
-    "birthdate": "PNtcyxm0Q5PyiBuG4f6eAbK6h4tF2FffwG3xqknZ_5A"
+    "birthdate": "1IjWWzdrXEs7iXUbsahdx_-8CIJsz2bcHHH_ccwgTBg",
+    "email": "gszmttjNfSw7_uL31KyJRvWgL1gHM6O3LFAzqxluWDQ",
+    "family_name": "Xbz5qK4Fqg-bS_CdwQYd_7qiNS9W810mRn42-FTHMPo",
+    "given_name": "asBCBSyK-B45q79qxGMe6j4MijK4lZsHHCD8O_jsDdc",
+    "other_secret_club_membership_no":
+      "3RP5qguZWamNuvdrFS-sqqYq_MaCIzx6Zn_bOZyE9BY",
+    "phone_number": "lB98F2RApo-ifhA3lwJGdqV-PAURkstN-oHmCv4LmxA",
+    "sub": "sJ88WF6Q05a2eyPnLJHXzZ8bbiQXWlXl44Nss7Ywk0E"
   }
 }
 ```
 
-In the II-Disclosures Object, it can be seen that the blinded claim's original name is `secret_club_membership_no`:
+In the II-Disclosures Object, it can be seen that the blinded claim's original name is `secret_club_membership_no`. Note again that the claims are sorted alphabetically as described in (#blinding-claim-names).
 
 
-{#example-simple_structured_some_blinded-svc_payload}
+{#example-simple_structured_some_blinded-iid_payload}
 ```json
 {
   "sd_ii_disclosures": {
-    "sub": "{\"s\": \"2GLC42sKQveCfGfryNRN9w\", \"v\":
-      \"6c5c0a49-b589-431d-bae7-219122a9ec2c\"}",
-    "given_name": "{\"s\": \"6Ij7tM-a5iVPGboS5tmvVA\", \"v\":
-      \"John\"}",
-    "family_name": "{\"s\": \"Qg_O64zqAxe412a108iroA\", \"v\":
-      \"Doe\"}",
-    "email": "{\"s\": \"Pc33JM2LchcU_lHggv_ufQ\", \"v\":
-      \"johndoe@example.com\"}",
-    "phone_number": "{\"s\": \"lklxF5jMYlGTPUovMNIvCA\", \"v\":
-      \"+1-202-555-0101\"}",
-    "5a2W0_NrlEZzfqmk_7Pq-w": "{\"s\": \"5bPs1IquZNa0hkaFzzzZNw\",
+    "HS4QoeE9ty-I8BZTEupSzw": "{\"s\": \"iq6rolXF0SyWSsdCeaETNg\",
       \"v\": \"23\", \"n\": \"secret_club_membership_no\"}",
-    "other_secret_club_membership_no": "{\"s\":
-      \"y1sVU5wdfJahVdgwPgS7RQ\", \"v\": \"42\"}",
     "address": {
-      "street_address": "{\"s\": \"C9GSoujviJquEgYfojCb1A\", \"v\":
-        \"123 Main St\"}",
-      "locality": "{\"s\": \"H3o1uswP760Fi2yeGdVCEQ\", \"v\":
+      "country": "{\"s\": \"l-6DlGlNloOsAUlBhMOt_Q\", \"v\":
+        \"US\"}",
+      "locality": "{\"s\": \"c6kc69Gmh04VVNPRlhOV_g\", \"v\":
         \"Anytown\"}",
-      "region": "{\"s\": \"M0Jb57t41ubrkSuyrDT3xA\", \"v\":
+      "region": "{\"s\": \"qwybxKQUee9A0mMhzGC-Pg\", \"v\":
         \"Anystate\"}",
-      "country": "{\"s\": \"eK5o5pHfgupPpltj1qhAJw\", \"v\": \"US\"}"
+      "street_address": "{\"s\": \"qNsw9K05ZngcEqXLEGalHA\", \"v\":
+        \"123 Main St\"}"
     },
-    "birthdate": "{\"s\": \"WpxJrFuX8uSi2p4ht09jvw\", \"v\":
-      \"1940-01-01\"}"
+    "birthdate": "{\"s\": \"OErzfd2Gy6jw1atlcCpr6A\", \"v\":
+      \"1940-01-01\"}",
+    "email": "{\"s\": \"woZIMokulfwyF_do1czRaA\", \"v\":
+      \"johndoe@example.com\"}",
+    "family_name": "{\"s\": \"ZXPEdf3K8mtRBKDAMjEcBQ\", \"v\":
+      \"Doe\"}",
+    "given_name": "{\"s\": \"btsLJCwSb0B7gtVLPMjjqA\", \"v\":
+      \"John\"}",
+    "other_secret_club_membership_no": "{\"s\":
+      \"Fj8RxKoVno-9SOVOEUoMpw\", \"v\": \"42\"}",
+    "phone_number": "{\"s\": \"YJSPlYo_aenthOCkapFRTg\", \"v\":
+      \"+1-202-555-0101\"}",
+    "sub": "{\"s\": \"Rj94TRxr3nvOw2WKtujLSA\", \"v\":
+      \"6c5c0a49-b589-431d-bae7-219122a9ec2c\"}"
   }
 }
 ```
 
 The verifier would learn this information via the HS-Disclosures JWT:
 
-{#example-simple_structured_some_blinded-sd_jwt_release_payload}
+{#example-simple_structured_some_blinded-hsd_jwt_payload}
 ```json
 {
   "nonce": "XZOUco1u_gEPknxS78sWWg",
   "aud": "https://example.com/verifier",
   "sd_hs_disclosures": {
-    "given_name": "{\"s\": \"6Ij7tM-a5iVPGboS5tmvVA\", \"v\":
+    "given_name": "{\"s\": \"btsLJCwSb0B7gtVLPMjjqA\", \"v\":
       \"John\"}",
-    "family_name": "{\"s\": \"Qg_O64zqAxe412a108iroA\", \"v\":
+    "family_name": "{\"s\": \"ZXPEdf3K8mtRBKDAMjEcBQ\", \"v\":
       \"Doe\"}",
-    "birthdate": "{\"s\": \"WpxJrFuX8uSi2p4ht09jvw\", \"v\":
+    "birthdate": "{\"s\": \"OErzfd2Gy6jw1atlcCpr6A\", \"v\":
       \"1940-01-01\"}",
     "address": {
-      "region": "{\"s\": \"M0Jb57t41ubrkSuyrDT3xA\", \"v\":
+      "region": "{\"s\": \"qwybxKQUee9A0mMhzGC-Pg\", \"v\":
         \"Anystate\"}",
-      "country": "{\"s\": \"eK5o5pHfgupPpltj1qhAJw\", \"v\": \"US\"}"
+      "country": "{\"s\": \"l-6DlGlNloOsAUlBhMOt_Q\", \"v\": \"US\"}"
     },
-    "5a2W0_NrlEZzfqmk_7Pq-w": "{\"s\": \"5bPs1IquZNa0hkaFzzzZNw\",
+    "HS4QoeE9ty-I8BZTEupSzw": "{\"s\": \"iq6rolXF0SyWSsdCeaETNg\",
       \"v\": \"23\", \"n\": \"secret_club_membership_no\"}"
   }
 }
@@ -1808,103 +1810,103 @@ The resulting SD-JWT payload:
 {#example-simple_structured_all_blinded-sd_jwt_payload}
 ```json
 {
-  "iss": "https://example.com/issuer",
   "cnf": {
     "jwk": {
+      "e": "AQAB",
       "kty": "RSA",
       "n": "pm4bOHBg-oYhAyPWzR56AWX3rUIXp11_ICDkGgS6W3ZWLts-hzwI3x656
         59kg4hVo9dbGoCJE3ZGF_eaetE30UhBUEgpGwrDrQiJ9zqprmcFfr3qvvkGjt
         th8Zgl1eM2bJcOwE7PCBHWTKWYs152R7g6Jg2OVph-a8rq-q79MhKG5QoW_mT
         z10QT_6H4c7PjWG1fjh8hpWNnbP_pv6d1zSwZfc5fl6yVRL0DV0V3lGHKe2Wq
         f_eNGjBrBLVklDTk8-stX_MWLcR-EGmXAOv0UBWitS_dXJKJu-vXJyw14nHSG
-        uxTIK2hx1pttMft9CsvqimXKeDTU14qQL1eE7ihcw",
-      "e": "AQAB"
+        uxTIK2hx1pttMft9CsvqimXKeDTU14qQL1eE7ihcw"
     }
   },
-  "iat": 1516239022,
   "exp": 1516247022,
+  "iat": 1516239022,
+  "iss": "https://example.com/issuer",
   "sd_digest_derivation_alg": "sha-256",
   "sd_digests": {
-    "eluV5Og3gSNII8EYnsxA_A":
-      "bvPLqohL5ROmk2UsuNffH8C1wx9o-ipm-G4SkUwrpAE",
-    "eI8ZWm9QnKPpNPeNenHdhQ":
-      "pCtjs0hC2Klhsnpe7BIqnGAsXlyXXC-lAEgX6isoYVM",
-    "AJx-095VPrpTtN4QMOqROA":
-      "HS1Ht-bTrXsSTw9JdcHIbTFDkEI_IY52_cmzUgxWZ0k",
-    "G02NSrQfjFXQ7Io09syajA":
-      "M2YQ_j8OPPBK3ZLhPPP6_AdSa2-rug2urYjgk_ML_QM",
-    "nPuoQnkRFq3BIeAm7AnXFA":
-      "-Brzrp2cs-8nLs7rQI89YJ76s3PrbVe3n_5hlYCy1cE",
-    "5a2W0_NrlEZzfqmk_7Pq-w":
-      "gc8VzGTImYRXzP6j7q5RomXt2C_wtsOJ3hAHJdTuEIY",
+    "3DOgmo7w7MDZNh1Zjvmwpg":
+      "OXZKGG7Ltar4vz_L7sAtWIkVXVf5r9xONFKZdyoNlco",
+    "7h5XiWrUSQLrv51P2vT3cA":
+      "K0oJkADnWjLY_MAZNXTN8bmHIjLNCxzCIOxwY8g1Mn8",
+    "CwiB46IUgi4NydIfgGTRwg":
+      "4miZg7O_JaidVJyjGiPpc4FXAMN16e1SBZfOMlYg3hQ",
+    "CzQ1rNB3tQmQT-jaW-uJTw":
+      "RsLvZebqpBpKp7xbIFAuhtrAx10Ry-6FKoABcbeg-Kw",
+    "FhBIPKqI5uQ_EtC_tmEJbA":
+      "ye5H2MwiXDx6725bILJIb46H5nfQ2MQ15ZOrYh2XxBQ",
     "address": {
-      "HbQ4X8srVW3QDxnIJdqyOA":
-        "39o5dKobVi8c0dLpg4sjd7zW18UONRra0ht9mgu4hec",
-      "kx5kF17V-x0JmwUx9vgvtw":
-        "wqueD5ABJ3bTyGSckOMpzI7YUvcCO2l-40vi6JMYsYY",
-      "OBKlTVlvLg-AdwqYGbP8ZA":
-        "S11dsdFN97YtrA2o3yZ0eBbf1zn-izejORU-fyMtynI",
-      "DsmtKNgpV4dAHpjrcaosAw":
-        "-0XEQHSNzMu244QaOpLmPD3JkdZN8SrqbEQ4VDufu9A"
+      "9svqZNCeiXlGrftK3HFwaA":
+        "w7K75-DbMddjAUF3gjfKGzMJGvc_WpmU1zMHyf1InLA",
+      "B-TASQbeBtkkfhAiuYxK0A":
+        "a6cCjb7594DQ0DVMhCHxBokV9XpxfIbkHg7kpSHkD6w",
+      "K7aYuNMfU49hD36pXsXK8Q":
+        "s098EJxC-8R8se_iIWRcVclkeDWkcJj-E3IqnAN4axI",
+      "oVemP2NxvQ6lnWpdKSrRig":
+        "cugLX_QPBOc4WBBshNt8v3Guo105CZdxfw6zxbpfwhI"
     },
-    "j7ADdb0UVb0Li0ciPcP0ew":
-      "X_v1hrkQIH_0LBM8TncMMTBzYN9UJc8FmJRda7yfY8g"
+    "w4Q6Tk6fSIOUc-vXKnhsUA":
+      "epjL-EKkkASHtsmFiKarvu56h1B3NvjUXUXeGWm2e8g",
+    "xf27CKc5bqY1ZHGI9M-bFA":
+      "nNbTObOY2Zt8ViP4MgFnhCAqgFKguHOFpRa0K31lPsM"
   }
 }
 ```
 
 The II-Disclosures Object:
-{#example-simple_structured_all_blinded-svc_payload}
+{#example-simple_structured_all_blinded-iid_payload}
 ```json
 {
   "sd_ii_disclosures": {
-    "eluV5Og3gSNII8EYnsxA_A": "{\"s\": \"2GLC42sKQveCfGfryNRN9w\",
-      \"v\": \"6c5c0a49-b589-431d-bae7-219122a9ec2c\", \"n\":
-      \"sub\"}",
-    "eI8ZWm9QnKPpNPeNenHdhQ": "{\"s\": \"6Ij7tM-a5iVPGboS5tmvVA\",
-      \"v\": \"John\", \"n\": \"given_name\"}",
-    "AJx-095VPrpTtN4QMOqROA": "{\"s\": \"Qg_O64zqAxe412a108iroA\",
-      \"v\": \"Doe\", \"n\": \"family_name\"}",
-    "G02NSrQfjFXQ7Io09syajA": "{\"s\": \"Pc33JM2LchcU_lHggv_ufQ\",
-      \"v\": \"johndoe@example.com\", \"n\": \"email\"}",
-    "nPuoQnkRFq3BIeAm7AnXFA": "{\"s\": \"lklxF5jMYlGTPUovMNIvCA\",
-      \"v\": \"+1-202-555-0101\", \"n\": \"phone_number\"}",
-    "5a2W0_NrlEZzfqmk_7Pq-w": "{\"s\": \"5bPs1IquZNa0hkaFzzzZNw\",
+    "3DOgmo7w7MDZNh1Zjvmwpg": "{\"s\": \"1-M9ZNF4mjcOxfLubDU5ZA\",
+      \"v\": \"1940-01-01\", \"n\": \"birthdate\"}",
+    "7h5XiWrUSQLrv51P2vT3cA": "{\"s\": \"kEHfe0_z3yvs5ejOMmfFUw\",
       \"v\": \"23\", \"n\": \"secret_club_membership_no\"}",
+    "CwiB46IUgi4NydIfgGTRwg": "{\"s\": \"fBXQPXk1pMU6resslYeSNg\",
+      \"v\": \"johndoe@example.com\", \"n\": \"email\"}",
+    "CzQ1rNB3tQmQT-jaW-uJTw": "{\"s\": \"XybH11hq3V7XygU5oe1UNw\",
+      \"v\": \"John\", \"n\": \"given_name\"}",
+    "FhBIPKqI5uQ_EtC_tmEJbA": "{\"s\": \"UVjLGL6QTThMSkWdam0TFg\",
+      \"v\": \"+1-202-555-0101\", \"n\": \"phone_number\"}",
     "address": {
-      "HbQ4X8srVW3QDxnIJdqyOA": "{\"s\": \"y1sVU5wdfJahVdgwPgS7RQ\",
+      "9svqZNCeiXlGrftK3HFwaA": "{\"s\": \"vlt16AiJ9p72_ELiVnCXpg\",
         \"v\": \"123 Main St\", \"n\": \"street_address\"}",
-      "kx5kF17V-x0JmwUx9vgvtw": "{\"s\": \"C9GSoujviJquEgYfojCb1A\",
+      "B-TASQbeBtkkfhAiuYxK0A": "{\"s\": \"jY-IPxzZeEJISV6AV8qE_A\",
+        \"v\": \"US\", \"n\": \"country\"}",
+      "K7aYuNMfU49hD36pXsXK8Q": "{\"s\": \"8DWvOZT4zodsKoNzzl_aGg\",
         \"v\": \"Anytown\", \"n\": \"locality\"}",
-      "OBKlTVlvLg-AdwqYGbP8ZA": "{\"s\": \"H3o1uswP760Fi2yeGdVCEQ\",
-        \"v\": \"Anystate\", \"n\": \"region\"}",
-      "DsmtKNgpV4dAHpjrcaosAw": "{\"s\": \"M0Jb57t41ubrkSuyrDT3xA\",
-        \"v\": \"US\", \"n\": \"country\"}"
+      "oVemP2NxvQ6lnWpdKSrRig": "{\"s\": \"6e_-fQrU5cTant3X74Q1kw\",
+        \"v\": \"Anystate\", \"n\": \"region\"}"
     },
-    "j7ADdb0UVb0Li0ciPcP0ew": "{\"s\": \"eK5o5pHfgupPpltj1qhAJw\",
-      \"v\": \"1940-01-01\", \"n\": \"birthdate\"}"
+    "w4Q6Tk6fSIOUc-vXKnhsUA": "{\"s\": \"pU_5H6WaSgldJX2nkbI6Hw\",
+      \"v\": \"Doe\", \"n\": \"family_name\"}",
+    "xf27CKc5bqY1ZHGI9M-bFA": "{\"s\": \"8_-KamhTL2yeQnrBvV1EDQ\",
+      \"v\": \"6c5c0a49-b589-431d-bae7-219122a9ec2c\", \"n\":
+      \"sub\"}"
   }
 }
 ```
 
 Here, the holder decided only to disclose a subset of the claims to the verifier:
 
-{#example-simple_structured_all_blinded-sd_jwt_release_payload}
+{#example-simple_structured_all_blinded-hsd_jwt_payload}
 ```json
 {
   "nonce": "XZOUco1u_gEPknxS78sWWg",
   "aud": "https://example.com/verifier",
   "sd_hs_disclosures": {
-    "eI8ZWm9QnKPpNPeNenHdhQ": "{\"s\": \"6Ij7tM-a5iVPGboS5tmvVA\",
+    "CzQ1rNB3tQmQT-jaW-uJTw": "{\"s\": \"XybH11hq3V7XygU5oe1UNw\",
       \"v\": \"John\", \"n\": \"given_name\"}",
-    "AJx-095VPrpTtN4QMOqROA": "{\"s\": \"Qg_O64zqAxe412a108iroA\",
+    "w4Q6Tk6fSIOUc-vXKnhsUA": "{\"s\": \"pU_5H6WaSgldJX2nkbI6Hw\",
       \"v\": \"Doe\", \"n\": \"family_name\"}",
-    "j7ADdb0UVb0Li0ciPcP0ew": "{\"s\": \"eK5o5pHfgupPpltj1qhAJw\",
+    "3DOgmo7w7MDZNh1Zjvmwpg": "{\"s\": \"1-M9ZNF4mjcOxfLubDU5ZA\",
       \"v\": \"1940-01-01\", \"n\": \"birthdate\"}",
     "address": {
-      "OBKlTVlvLg-AdwqYGbP8ZA": "{\"s\": \"H3o1uswP760Fi2yeGdVCEQ\",
+      "oVemP2NxvQ6lnWpdKSrRig": "{\"s\": \"6e_-fQrU5cTant3X74Q1kw\",
         \"v\": \"Anystate\", \"n\": \"region\"}",
-      "DsmtKNgpV4dAHpjrcaosAw": "{\"s\": \"M0Jb57t41ubrkSuyrDT3xA\",
+      "B-TASQbeBtkkfhAiuYxK0A": "{\"s\": \"jY-IPxzZeEJISV6AV8qE_A\",
         \"v\": \"US\", \"n\": \"country\"}"
     }
   }

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -990,7 +990,7 @@ distinguish what claim name has been hidden just by observing the order
 of blinded and unblinded claim names. It is therefore RECOMMENDED, if at
 least one claim name is blinded, to either 
 
- * randomize the order of all claims,
+ * randomize the order of all claims (blinded/unblinded, selectively disclosed/not-selectively disclosed),
  * or sort the claims by the property name (i.e., the placeholder claim
    name for blinded claim names and the plaintext claim name for
    unblinded claim names). The precise order does not matter. For

--- a/sd_jwt/bin/sd_jwt
+++ b/sd_jwt/bin/sd_jwt
@@ -109,7 +109,21 @@ jwk_kwargs = {
     "key_size": settings.DEFAULT_KEY_SIZE,
     "kty": settings.DEFAULT_KTY,
 }
-_JWKS = get_jwk(jwk_kwargs, _args.no_randomness)
+
+# If "no randomness" is requested, we hash the file name of the example
+# file to use it as the random seed. This ensures that the same example
+# file always generates the same output, but the output between
+# different example files is different.
+if _args.no_randomness:
+    import hashlib
+
+    hash_object = hashlib.sha256(_args.example.read_bytes())
+    # Extract the hash as integer
+    seed = int(hash_object.hexdigest(), 16)
+else:
+    seed = None
+
+_JWKS = get_jwk(jwk_kwargs, _args.no_randomness, seed)
 ISSUER_KEY = _JWKS["ISSUER_KEY"]
 HOLDER_KEY = _JWKS["HOLDER_KEY"]
 ISSUER_PUBLIC_KEY = _JWKS["ISSUER_PUBLIC_KEY"]

--- a/sd_jwt/demo_utils.py
+++ b/sd_jwt/demo_utils.py
@@ -28,7 +28,7 @@ def print_decoded_repr(value: str, nlines=2):
     print("\n.\n".join(seq), end=_nlines)
 
 
-def get_jwk(jwk_kwargs: dict = {}, no_randomness: bool = False):
+def get_jwk(jwk_kwargs: dict = {}, no_randomness: bool = False, random_seed: int = 0):
     """
     jwk_kwargs = {
         iss_key:dict : {},
@@ -40,7 +40,7 @@ def get_jwk(jwk_kwargs: dict = {}, no_randomness: bool = False):
     returns static or random JWK
     """
     if no_randomness:
-        random.seed(0)
+        random.seed(random_seed)
         ISSUER_KEY = JWK.from_json(json.dumps(jwk_kwargs["iss_key"]))
         HOLDER_KEY = JWK.from_json(json.dumps(jwk_kwargs["holder_key"]))
         logger.warning("Using fixed randomness for demo purposes")

--- a/sd_jwt/operations.py
+++ b/sd_jwt/operations.py
@@ -10,7 +10,7 @@ from jwcrypto.jwk import JWK
 from jwcrypto.jws import JWS
 
 from sd_jwt import DEFAULT_SIGNING_ALG, DIGEST_ALG_KEY, SD_II_CLAIMS_KEY, SD_HS_CLAIMS_KEY, SD_DIGESTS_KEY
-from sd_jwt.utils import generate_salt, pad_urlsafe_b64, merge
+from sd_jwt.utils import generate_salt, pad_urlsafe_b64, merge, sort_dict
 from sd_jwt.walk import by_structure as walk_by_structure
 
 
@@ -101,6 +101,11 @@ class SDJWT:
                 self._create_sd_claim_entry,
             ),
         }
+
+        # If any of the claim names are blinded, sort the SD-JWT contents.
+        if self._blinded_claim_names:
+            self.sd_jwt_payload = sort_dict(self.sd_jwt_payload)
+
         self.sd_jwt_payload.update(self._further_claims)
 
     def _hash_raw(self, raw):
@@ -169,6 +174,11 @@ class SDJWT:
             ),
             # "cnf_private": issuer_key.export_private(as_dict=True),
         }
+
+        # If any of the claim names are blinded, sort the SVC contents.
+        if self._blinded_claim_names:
+            self.svc_payload = sort_dict(self.svc_payload)
+
         self.serialized_svc = (
             urlsafe_b64encode(dumps(self.svc_payload).encode())
             .decode("ascii")

--- a/sd_jwt/utils.py
+++ b/sd_jwt/utils.py
@@ -14,13 +14,26 @@ def generate_salt():
         .strip("=")
     )
 
+
 # Deep merge two dicts, with the second dict taking precedence
 def merge(dict_a, dict_b):
     for key in dict_b:
-        if key in dict_a and isinstance(dict_a[key], dict) and isinstance(
-            dict_b[key], dict
+        if (
+            key in dict_a
+            and isinstance(dict_a[key], dict)
+            and isinstance(dict_b[key], dict)
         ):
             merge(dict_a[key], dict_b[key])
         else:
             dict_a[key] = dict_b[key]
     return dict_a
+
+
+# Python preserves the order of keys in dicts. This function sorts dicts by keys, recursively.
+def sort_dict(d):
+    if isinstance(d, dict):
+        return {k: sort_dict(v) for k, v in sorted(d.items())}
+    elif isinstance(d, list):
+        return [sort_dict(v) for v in d]
+    else:
+        return d


### PR DESCRIPTION
This was missing before, even though it is important for privacy.

This patch also ensures that *different* random numbers are used for the generation of each example. 