### PR TITLE
updated a linkability section based on the UL feedback

### DIFF
--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -1174,10 +1174,13 @@ Furthermore, re-using the same value to blind a claim name may limit the privacy
 
 ## Unlinkability
 
-Colluding Issuer/Verifier or Verifier/Verifier pairs could link issuance/presentation or two presentation sessions
-to the same user on the basis of unique values encoded in the SD-JWT
-(Issuer signature, salts, digests, etc.). More advanced cryptographic schemes, outside the scope of
-this specification, can be used to prevent this type of linkability.
+Colluding Issuer/Verifier or Verifier/Verifier pairs could link issuance/presentation 
+or two presentation sessions to the same user on the basis of unique values encoded in the SD-JWT
+(Issuer signature, salts, digests, etc.). 
+
+To prevent these types of linkability, various methods, including but not limited to the following ones can be used:
+- Use advanced cryptographic schemes, outside the scope of this specification.
+- Issue a barch of SD-JWTs to the Holder to enable the Holder to use a unique SD-JWT per Verifier. This only helps with Verifier/Verifier unlinkability.
 
 # Acknowledgements {#Acknowledgements}
 

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -1179,8 +1179,9 @@ or two presentation sessions to the same user on the basis of unique values enco
 (Issuer signature, salts, digests, etc.). 
 
 To prevent these types of linkability, various methods, including but not limited to the following ones can be used:
+
 - Use advanced cryptographic schemes, outside the scope of this specification.
-- Issue a barch of SD-JWTs to the Holder to enable the Holder to use a unique SD-JWT per Verifier. This only helps with Verifier/Verifier unlinkability.
+- Issue a batch of SD-JWTs to the Holder to enable the Holder to use a unique SD-JWT per Verifier. This only helps with Verifier/Verifier unlinkability.
 
 # Acknowledgements {#Acknowledgements}
 

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -1186,14 +1186,17 @@ To prevent these types of linkability, various methods, including but not limite
 
 We would like to thank
 Alen Horvat,
+Arjan Geluk,
 Brian Campbell,
 Christian Paquin,
+David Bakker,
 Fabian Hauck,
 Giuseppe De Marco,
 Kushal Das,
 Mike Jones,
 Nat Sakimura,
 Pieter Kasselman,
+Ryosuke Abe,
 Shawn Butterfield, and
 Torsten Lodderstedt
 for their contributions (some of which substantial) to this draft and to the initial set of implementations.


### PR DESCRIPTION
Added an option to do pairwise SD-JWTs to prevent Verifier/Verifier linkability

Original feedback.

> The discussion of linkability in section 8.2 is incomplete. It actually gives the impression that linkability is unavoidable if this RFC is implemented, since for a solution it only refers to undefined ‘advanced cryptographic schemes outside the scope of this specification’. However, in reality an issuer can completely avoid linkability on the basis of unique values encoded in the SD-JWT, simply by ensuring that each SD-JWT can be used for only one transaction. Of course, this places stringent demands on the connectivity of the holder app and the capacity of the issuer’s systems for generating and communicating new SD-JWTs to its holder apps. To lessen these burdens, the issuer could also choose other approaches, for example 
> - Equipping each holder app with a pool of (for instance) 20 different SD-JWTs. The app would then randomly pick one of these SD-JWTs for every transaction, and re-start the pool once all JWTs have been used. 
> - Allowing each SD-JWT to be used multiple times, but only for a limited time.
> 
> The SD-JWT mechanism therefore allows every issuer to find the correct balance between holder linkability and mitigation costs and efforts, based on a risk analysis for their specific situation.
Please re-write section 8.2 in the light of the above suggestions.
