### PR TITLE
Tidy up example in Appendix 4

### DIFF
--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -1105,18 +1105,7 @@ The following data will be used in this example:
 
 <{{examples/w3c-vc/user_claims.json}}
 
-The encoded SD-JWT looks as follows:
-
-Header:
-```json
-{
-  "typ": "sd-jwt-vc",
-  "alg": "RS256",
-  "kid": "cAEIUqJ0cmLzD1kzGzheiBag0YRAzVdlfxN280NgHaA"
-}
-```
-
-Body:
+The payload of a corresponding SD-JWT looks as follows:
 
 <{{examples/w3c-vc/sd_jwt_payload.json}}
 


### PR DESCRIPTION
basically removing the example JWT header JSON (which aren't shown elsewhere FWIW) that had a fictitious `typ` and meaningless `kid` and didn't add anything to understanding/following the example 