### PR TITLE
updating Privacy Considerations

### DIFF
--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -830,8 +830,8 @@ This specification therefore considers the confidentiality of the data to be
 provided by the transport protocol and does not specify any encryption
 mechanism.
 
-Implementers MUST ensure that the transport protocol provides confidentiality,
-if the privacy of End-User data or correlation attacks by the passive observers are a concern. Implementers MAY define an
+Implementers MUST ensure that the transport protocol provides confidentiality
+if the privacy of End-User data or correlation attacks by passive observers are a concern. Implementers MAY define an
 envelope format (such as described in (#enveloping) or nesting the SD-JWT Combined Format as
 the plaintext payload of a JWE) to encrypt the SD-JWT
 and associated Disclosures when transmitted over an insecure channel.
@@ -856,13 +856,13 @@ To prevent these types of linkability, various methods, including but not limite
 
 ## Issuer Identifier
 
-Issuer issuing only one type of SD-JWT might have privacy implications, because if the Holder has an SD-JWT issued by that Issuer, its type and claim names can be determined.
+An Issuer issuing only one type of SD-JWT might have privacy implications, because if the Holder has an SD-JWT issued by that Issuer, its type and claim names can be determined.
 
 For example, if the National Cancer Institute only issued SD-JWTs with cancer registry information, it is possible to deduce that the Holder owning its SD-JWT is a cancer patient.
 
-Moreover, issuer identifier alone may reveal information about the user.
+Moreover, the issuer identifier alone may reveal information about the user.
 
-For example, when a military organization or a drug rehab center issues a vaccine credential, verifiers can deduce that the holder is a military member or has a substance use disorder.
+For example, when a military organization or a drug rehabilitation center issues a vaccine credential, verifiers can deduce that the holder is a military member or may have a substance use disorder.
 
 To mitigate this issue, a group of issuers may elect to use a common Issuer identifier. A group signature scheme outside the scope of this specification may also be used, instead of an individual signature.
 

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -770,7 +770,7 @@ key-distribution method.
 
 # Privacy Considerations {#privacy_considerations}
 
-The privacy principles of [@ISO.29100] MUST be adhered to.
+The privacy principles of [@ISO.29100] should be adhered to.
 
 ## Storage of Signed User Data
 

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -865,7 +865,7 @@ Moreover, issuer identifier alone may reveal information about the user.
 
 For example, when a military organization or a drug rehab center issues a vaccine credential, verifiers can deduce that the holder is a military member or has a substance use disorder.
 
-To mitigate this issue, a group of issuers may elect to use a common Issuer identifier, or use a group signature scheme instead of an individual signature.
+To mitigate this issue, a group of issuers may elect to use a common Issuer identifier. A group signature scheme outside the scope of this specification may also be used, instead of an individual signature.
 
 # Acknowledgements {#Acknowledgements}
 

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -831,7 +831,7 @@ provided by the transport protocol and does not specify any encryption
 mechanism.
 
 Implementers MUST ensure that the transport protocol provides confidentiality,
-if the privacy of End-User data or correlation attacks are a concern. Implementers MAY define an
+if the privacy of End-User data or correlation attacks by the passive observers are a concern. Implementers MAY define an
 envelope format (such as described in (#enveloping) or nesting the SD-JWT Combined Format as
 the plaintext payload of a JWE) to encrypt the SD-JWT
 and associated Disclosures when transmitted over an insecure channel.
@@ -853,7 +853,9 @@ To prevent these types of linkability, various methods, including but not limite
 - Use advanced cryptographic schemes, outside the scope of this specification.
 - Issue a batch of SD-JWTs to the Holder to enable the Holder to use a unique SD-JWT per Verifier. This only helps with Verifier/Verifier unlinkability.
 
-## Issuer Issuing only One Type of D-JWT
+Colluding Verifier/Verifier pairs correspond to RP+RP'-U Unlinkability as defined in [@ISO.27551].
+
+## Issuer Issuing One Type of SD-JWT
 
 Issuer issuing only one type of SD-JWT might have privacy implications, because if the Holder has an SD-JWT issued by that Issuer, its type and claim names can be determined.
 
@@ -917,6 +919,13 @@ TBD
 <reference anchor="ISO.29100" target="https://standards.iso.org/ittf/PubliclyAvailableStandards/index.html">
   <front>
     <title>ISO/IEC 29100:2011 Information technology — Security techniques — Privacy framework</title>
+   <date year="2011"/>
+  </front>
+</reference>
+
+<reference anchor="ISO.27551" target="https://www.iso.org/standard/72018.html">
+  <front>
+    <title>ISO/IEC 27551:2021 Information security, cybersecurity and privacy protection — Requirements for attribute-based unlinkable entity authentication</title>
    <date year="2011"/>
   </front>
 </reference>

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -921,8 +921,8 @@ TBD
 
 <reference anchor="ISO.29100" target="https://standards.iso.org/ittf/PubliclyAvailableStandards/index.html">
   <front>
+    <author fullname="ISO"></author>
     <title>ISO/IEC 29100:2011 Information technology — Security techniques — Privacy framework</title>
-   <date year="2011"/>
   </front>
 </reference>
 

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -853,7 +853,6 @@ To prevent these types of linkability, various methods, including but not limite
 - Use advanced cryptographic schemes, outside the scope of this specification.
 - Issue a batch of SD-JWTs to the Holder to enable the Holder to use a unique SD-JWT per Verifier. This only helps with Verifier/Verifier unlinkability.
 
-Colluding Verifier/Verifier pairs correspond to RP+RP'-U Unlinkability as defined in [@ISO.27551].
 
 ## Issuer Identifier
 
@@ -923,13 +922,6 @@ TBD
 <reference anchor="ISO.29100" target="https://standards.iso.org/ittf/PubliclyAvailableStandards/index.html">
   <front>
     <title>ISO/IEC 29100:2011 Information technology — Security techniques — Privacy framework</title>
-   <date year="2011"/>
-  </front>
-</reference>
-
-<reference anchor="ISO.27551" target="https://www.iso.org/standard/72018.html">
-  <front>
-    <title>ISO/IEC 27551:2021 Information security, cybersecurity and privacy protection — Requirements for attribute-based unlinkable entity authentication</title>
    <date year="2011"/>
   </front>
 </reference>

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -855,11 +855,15 @@ To prevent these types of linkability, various methods, including but not limite
 
 Colluding Verifier/Verifier pairs correspond to RP+RP'-U Unlinkability as defined in [@ISO.27551].
 
-## Issuer Issuing One Type of SD-JWT
+## Issuer Identifier
 
 Issuer issuing only one type of SD-JWT might have privacy implications, because if the Holder has an SD-JWT issued by that Issuer, its type and claim names can be determined.
 
 For example, if the National Cancer Institute only issued SD-JWTs with cancer registry information, it is possible to deduce that the Holder owning its SD-JWT is a cancer patient.
+
+Moreover, issuer identifier alone may reveal information about the user. 
+
+For example, when a military organization or a drug rehab center issues a vaccine credential, verifiers can deduce that the holder is a military member or has a substance use disorder.
 
 To mitigate this issue, a group of issuers may elect to use a common Issuer identifier, or use a group signature scheme instead of an individual signature.
 

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -861,7 +861,7 @@ Issuer issuing only one type of SD-JWT might have privacy implications, because 
 
 For example, if the National Cancer Institute only issued SD-JWTs with cancer registry information, it is possible to deduce that the Holder owning its SD-JWT is a cancer patient.
 
-Moreover, issuer identifier alone may reveal information about the user. 
+Moreover, issuer identifier alone may reveal information about the user.
 
 For example, when a military organization or a drug rehab center issues a vaccine credential, verifiers can deduce that the holder is a military member or has a substance use disorder.
 

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -770,7 +770,7 @@ key-distribution method.
 
 # Privacy Considerations {#privacy_considerations}
 
-The privacy principles of [@ISO.29100] MUST be adhered to. 
+The privacy principles of [@ISO.29100] MUST be adhered to.
 
 ## Storage of Signed User Data
 

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -770,6 +770,8 @@ key-distribution method.
 
 # Privacy Considerations {#privacy_considerations}
 
+The privacy principles of [@ISO.29100] MUST be adhered to. 
+
 ## Storage of Signed User Data
 
 Wherever End-User data is stored, it represents a potential
@@ -851,6 +853,14 @@ To prevent these types of linkability, various methods, including but not limite
 - Use advanced cryptographic schemes, outside the scope of this specification.
 - Issue a batch of SD-JWTs to the Holder to enable the Holder to use a unique SD-JWT per Verifier. This only helps with Verifier/Verifier unlinkability.
 
+## Issuer Issuing only One Type of D-JWT
+
+Issuer issuing only one type of SD-JWT might have privacy implications, because if the Holder has an SD-JWT issued by that Issuer, its type and claim names can be determined.
+
+For example, if the National Cancer Institute only issued SD-JWTs with cancer registry information, it is possible to deduce that the Holder owning its SD-JWT is a cancer patient.
+
+To mitigate this issue, a group of issuers may elect to use a common Issuer identifier, or use a group signature scheme instead of an individual signature.
+
 # Acknowledgements {#Acknowledgements}
 
 We would like to thank
@@ -901,6 +911,13 @@ TBD
       <organization>Salesforce</organization>
     </author>
    <date day="8" month="Nov" year="2014"/>
+  </front>
+</reference>
+
+<reference anchor="ISO.29100" target="https://standards.iso.org/ittf/PubliclyAvailableStandards/index.html">
+  <front>
+    <title>ISO/IEC 29100:2011 Information technology — Security techniques — Privacy framework</title>
+   <date year="2011"/>
   </front>
 </reference>
 


### PR DESCRIPTION
When merged, this PR replaces PR #93 and closes Issue #91.

- I am not sure what value reference to ISO 27551 brings (+1 to remove it). 
   - Unlinkability pairs defined in ISO27551 do not really apply to Issuer-Holder-Verifier model, since they are modelled after User Agent-RP model. 
   - and anonymity of the User is out of scope for SD-JWT IMO, but adding one subsection on "User identifier should be chosen to guarantee user anonymity and not only pseudonymity". but feels redundant since SD-JWT is not only for natural persons..
- Some of the notions in PR 93 were outdated since claim names are now blinded by default.
- "Issuer Issuing One Type of SD-JWT" section might be valuable, also confirming with Smart health card community.