### PR TITLE
fix: [Hash algs] only RIPEMD versions earlier that 160 are not usable.

### DIFF
--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -719,7 +719,7 @@ alone does not indicate a hash algorithm's suitability for use in SD-JWT (it con
 heavily truncated digests, such as `sha-256-32` and `sha-256-64`, which are unfit for security
 applications).
 
-Furthermore, the hash algorithms MD2, MD4, MD5, RIPEMD-160, and SHA-1
+Furthermore, the hash algorithms MD2, MD4, MD5, SHA-1 and RIPEMD versions previous than 160,
 revealed fundamental weaknesses and they MUST NOT be used.
 
 ## Holder Binding {#holder_binding_security}

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -719,7 +719,7 @@ alone does not indicate a hash algorithm's suitability for use in SD-JWT (it con
 heavily truncated digests, such as `sha-256-32` and `sha-256-64`, which are unfit for security
 applications).
 
-Furthermore, the hash algorithms MD2, MD4, MD5, SHA-1 and RIPEMD versions previous than 160,
+Furthermore, the hash algorithms MD2, MD4, MD5, and SHA-1
 revealed fundamental weaknesses and they MUST NOT be used.
 
 ## Holder Binding {#holder_binding_security}


### PR DESCRIPTION
RIPEMD-160 is usable, but not its predecessors. 

For this reason this PR removes RIPEMD-160 from the list of the weak algs by saying that only  -160 predecessors must not be used.