### PR TITLE
merge processing rules for the wallet and the verifier

### DIFF
--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -685,15 +685,15 @@ an SD-JWT:
     3. (**) For each embedded digest found in the previous step:
        1. Compare the value with the digests calculated previously and find the matching Disclosure. If no such Disclosure can be found, the digest MUST be ignored.
        2. If the digest was found in an object's `_sd` key:
-          1. If the respective Disclosure is not a JSON-encoded array of three elements, the Verifier MUST reject the Presentation.
+          1. If the respective Disclosure is not a JSON-encoded array of three elements, the SD-JWT MUST be rejected.
           2. Insert, at the level of the `_sd` key, a new claim using the claim name and claim value from the Disclosure.
-          3. If the claim name already exists at the same level, the Verifier MUST reject the Presentation.
+          3. If the claim name already exists at the same level, the SD-JWT MUST be rejected.
           4. Recursively process the value using the steps described in (*) and (**).
        3. If the digest was found in an array element:
-          1. If the respective Disclosure is not a JSON-encoded array of two elements, the Verifier MUST reject the Presentation.
+          1. If the respective Disclosure is not a JSON-encoded array of two elements, the SD-JWT MUST be rejected.
           2. Replace the array element with the claim value from the Disclosure.
           3. Recursively process the value using the steps described in (*) and (**).
-    4. If any digests were found more than once in the previous step, the Verifier MUST reject the Presentation.
+    4. If any digests were found more than once in the previous step, the SD-JWT MUST be rejected.
     5. Remove all array elements for which the digest was not found in the previous step.
     6. Remove all `_sd` keys and their contents from the issuer-signed JWT payload.
     7. Remove the claim `_sd_alg` from the SD-JWT payload.

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -1543,7 +1543,7 @@ data. The original JSON data is then used by the application. See
    [[ To be removed from the final specification ]]
 
    -05
-
+   * Consolidate processing rules for Holder and Verifier
    * Add support for selective disclosure of array elements.
    * Use the term Key Binding rather than Holder Binding
    * Defined the structure of the Key Binding JWT

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -659,7 +659,7 @@ the claims `given_name`, `family_name`, and `address`, as it would be sent from 
 
 # Verification and Processing {#verification}
 
-## Processing of the SD-JWT {#sd_jwt_verification}
+## Verification of the SD-JWT {#sd_jwt_verification}
 
 Upon receiving an SD-JWT, the Wallets and the Verifiers MUST ensure that
 

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -690,7 +690,7 @@ For presentation to a Verifier, the Holder MUST perform the following (or equiva
 
  1. Decide which Disclosures to release to the Verifier, obtaining proper End-User consent if necessary.
  2. If Key Binding is required, create a Key Binding JWT.
- 3. Assemble the SD-JWT for Presentation, including the selected Disclosures and, if applicable, the Key Binding JWT.
+ 3. Assemble the SD-JWT for Presentation, including the Issuer-signed JWT, the selected Disclosures and, if applicable, the Key Binding JWT.
  4. Send the Presentation to the Verifier.
 
 ## Verification by the Verifier  {#verifier_verification}

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -76,7 +76,7 @@ the Verifier becomes crucial to ensure minimum disclosure and prevent
 Verifiers from obtaining claims irrelevant for the transaction at hand.
 SD-JWTs defined in this document enable such selective disclosure of JWT claims.
 
-One example of a multi-use JWT is a verifiable credential, an issuer-signed
+One example of a multi-use JWT is a verifiable credential, an Issuer-signed
 credential that contains the claims about a subject, and whose authenticity can be
 cryptographically verified.
 
@@ -663,23 +663,23 @@ the claims `given_name`, `family_name`, and `address`, as it would be sent from 
 
 Upon receiving an SD-JWT, the Holders and the Verifiers MUST ensure that
 
- * the issuer-signed JWT is valid, i.e., it is signed by the Issuer and the signature is valid, and
- * all Disclosures are correct, i.e., their digests are referenced in the issuer-signed JWT.
+ * the Issuer-signed JWT is valid, i.e., it is signed by the Issuer and the signature is valid, and
+ * all Disclosures are correct, i.e., their digests are referenced in the Issuer-signed JWT.
 
 The Holder and the Verifier perform the following (or equivalent) steps when receiving
 an SD-JWT:
 
- 1. Separate the SD-JWT into the issuer-signed JWT and the Disclosures (if any).
- 2. Validate the issuer-signed JWT:
+ 1. Separate the SD-JWT into the Issuer-signed JWT and the Disclosures (if any).
+ 2. Validate the Issuer-signed JWT:
     1. Ensure that a signing algorithm was used that was deemed secure for the application. Refer to [@RFC8725], Sections 3.1 and 3.2 for details. The `none` algorithm MUST NOT be accepted.
-    2. Validate the signature over the issuer-signed JWT.
+    2. Validate the signature over the Issuer-signed JWT.
     3. Validate the Issuer and that the signing key belongs to this Issuer.
-    4. Check that the issuer-signed JWT is valid using `nbf`, `iat`, and `exp` claims, if provided in the SD-JWT, and not selectively disclosed.
+    4. Check that the Issuer-signed JWT is valid using `nbf`, `iat`, and `exp` claims, if provided in the SD-JWT, and not selectively disclosed.
     5. Check that the `_sd_alg` claim value is understood and the hash algorithm is deemed secure.
  3. Process the Disclosures and embedded digests in the issuser-signed JWT as follows:
     1. For each Disclosure provided:
        1. Calculate the digest over the base64url-encoded string as described in (#hashing_disclosures).
-    2. (*) Identify all embedded digests in the issuer-signed JWT as follows:
+    2. (*) Identify all embedded digests in the Issuer-signed JWT as follows:
        1. Find all objects having an `_sd` key that refers to an array of strings.
        2. Find all array elements that are objects with one key, that key being `...` and referring to a string.
     3. (**) For each embedded digest found in the previous step:
@@ -695,7 +695,7 @@ an SD-JWT:
           3. Recursively process the value using the steps described in (*) and (**).
     4. If any digests were found more than once in the previous step, the SD-JWT MUST be rejected.
     5. Remove all array elements for which the digest was not found in the previous step.
-    6. Remove all `_sd` keys and their contents from the issuer-signed JWT payload.
+    6. Remove all `_sd` keys and their contents from the Issuer-signed JWT payload.
     7. Remove the claim `_sd_alg` from the SD-JWT payload.
 
 If any step fails, the SD-JWT is not valid and processing MUST be aborted.
@@ -1543,6 +1543,7 @@ data. The original JSON data is then used by the application. See
    [[ To be removed from the final specification ]]
 
    -05
+
    * Consolidate processing rules for Holder and Verifier
    * Add support for selective disclosure of array elements.
    * Use the term Key Binding rather than Holder Binding

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -669,7 +669,7 @@ Upon receiving an SD-JWT, a Holder or a Verifier MUST ensure that
 The Holder or the Verifier MUST perform the following (or equivalent) steps when receiving
 an SD-JWT:
 
- 1. Separate the SD-JWT into the issuer-signed JWT, the Disclosures (if any), and the Key Binding JWT (if present). 
+ 1. Separate the SD-JWT into the Issuer-signed JWT, the Disclosures (if any), and the Key Binding JWT (if present). 
  2. Validate the Issuer-signed JWT:
     1. Ensure that a signing algorithm was used that was deemed secure for the application. Refer to [@RFC8725], Sections 3.1 and 3.2 for details. The `none` algorithm MUST NOT be accepted.
     2. Validate the signature over the Issuer-signed JWT.

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -669,7 +669,7 @@ Upon receiving an SD-JWT, a Holder or a Verifier MUST ensure that
 The Holder or the Verifier MUST perform the following (or equivalent) steps when receiving
 an SD-JWT:
 
- 1. Separate the SD-JWT into the Issuer-signed JWT and the Disclosures (if any).
+ 1. Separate the SD-JWT into the issuer-signed JWT, the Disclosures (if any), and the Key Binding JWT (if present). 
  2. Validate the Issuer-signed JWT:
     1. Ensure that a signing algorithm was used that was deemed secure for the application. Refer to [@RFC8725], Sections 3.1 and 3.2 for details. The `none` algorithm MUST NOT be accepted.
     2. Validate the signature over the Issuer-signed JWT.
@@ -704,6 +704,8 @@ It is up to the Holder how to maintain the mapping between the Disclosures and t
 
 ## Processing by the Holder  {#holder_verification}
 
+If a Key Binding JWT is received by a Holder, the SD-JWT SHOULD be rejected.
+
 For presentation to a Verifier, the Holder MUST perform the following (or equivalent) steps:
 
  1. Decide which Disclosures to release to the Verifier, obtaining proper End-User consent if necessary.
@@ -723,8 +725,7 @@ To this end, Verifiers MUST follow the following steps (or equivalent):
     for the use case at hand. This decision MUST NOT be based on whether
     a Key Binding JWT is provided by the Holder or not. Refer to (#key_binding_security) for
     details.
- 2. Separate the Presentation into the SD-JWT, and the Key Binding JWT (if provided).
- 3. Process the SD-JWT as defined in (#sd_jwt_verification).
+ 2. Process the SD-JWT as defined in (#sd_jwt_verification).
  3. If Key Binding is required:
     1. If Key Binding is provided by means not defined in this specification, verify the Key Binding according to the method used.
     2. Otherwise, verify the Key Binding JWT as follows:

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -661,7 +661,7 @@ the claims `given_name`, `family_name`, and `address`, as it would be sent from 
 
 ## Verification of the SD-JWT {#sd_jwt_verification}
 
-Upon receiving an SD-JWT, the Wallets and the Verifiers MUST ensure that
+Upon receiving an SD-JWT, the Holders and the Verifiers MUST ensure that
 
  * the issuer-signed JWT is valid, i.e., it is signed by the Issuer and the signature is valid, and
  * all Disclosures are correct, i.e., their digests are referenced in the issuer-signed JWT.
@@ -708,7 +708,7 @@ For presentation to a Verifier, the Holder MUST perform the following (or equiva
 
  1. Decide which Disclosures to release to the Verifier, obtaining proper End-User consent if necessary.
  2. If Key Binding is required, create a Key Binding JWT.
- 3. Create the Combined Format for Presentation, including the selected Disclosures and, if applicable, the Key Binding JWT.
+ 3. Assemble the SD-JWT for Presentation, including the selected Disclosures and, if applicable, the Key Binding JWT.
  4. Send the Presentation to the Verifier.
 
 ## Verification by the Verifier  {#verifier_verification}

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -649,7 +649,7 @@ Upon receiving an SD-JWT, a Holder or a Verifier MUST ensure that
 The Holder or the Verifier MUST perform the following (or equivalent) steps when receiving
 an SD-JWT:
 
- 1. Separate the SD-JWT into the Issuer-signed JWT, the Disclosures (if any), and the Key Binding JWT (if present). 
+ 1. Separate the SD-JWT into the Issuer-signed JWT, the Disclosures (if any), and the Key Binding JWT (if present).
  2. Validate the Issuer-signed JWT:
     1. Ensure that a signing algorithm was used that was deemed secure for the application. Refer to [@RFC8725], Sections 3.1 and 3.2 for details. The `none` algorithm MUST NOT be accepted.
     2. Validate the signature over the Issuer-signed JWT.

--- a/examples/simple/specification.yml
+++ b/examples/simple/specification.yml
@@ -4,12 +4,14 @@ user_claims:
   !sd family_name: Doe
   !sd email: johndoe@example.com
   !sd phone_number: +1-202-555-0101
+  !sd phone_number_verified: true
   !sd address:
     street_address: 123 Main St
     locality: Anytown
     region: Anystate
     country: US
   !sd birthdate: "1940-01-01"
+  !sd updated_at: 1570000000
   nationalities: [!sd "US", !sd "DE"]
 
 holder_disclosed_claims:


### PR DESCRIPTION
changes.
- created a common sd-jwt verification section
- wallet processing section talks only about presentation creation
- verifier processing section talks only about key binding JWT processing and refers to a common sd-jwt verification section

Note that the terminology is new - based on the PR that @bc-pi is doing for issue #254 (probably not touching these sections in your PR might be the best to minimize conflict, Brian, or I can push later to your branch - wanted to do this PR while I had the idea fresh in my head). I used `issuer-signed JWT` as a placeholder. 