### PR TITLE
Fix Issue #299 by moving to a better example

### DIFF
--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -1484,7 +1484,7 @@ or as
 ...
 ```
 
-The two representations `"M\u00f6bius"` and `"Möbius"` are very different on the byte-level, but yield
+The two representations of the value in `family_name` are very different on the byte-level, but yield
 equivalent objects. Same for the representations of `address`, varying in white space and order of elements in the object.
 
 The variations in white space, ordering of object properties, and

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -1555,6 +1555,7 @@ data. The original JSON data is then used by the application. See
    * Added considerations around forwarding credentials
    * Removed Example 2b and merged the demo of decoy digests into Example 2a
    * Updated title to be more inclusive of JWS with JSON and added some corresponding text to the Abstract and Intro
+   * Improved example for allowed variations in Disclosures
 
    -04
 

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -302,7 +302,7 @@ white space, encoding of Unicode characters, and ordering of object properties
 are allowed. For example, the following strings are all valid and encode the
 same claim value "Möbius":
 
- * A different way to encode the umlaut (two dots `¨` placed over the letter):\
+ * A different way to encode the unicode umlaut:\
 `WyJfMjZiYzRMVC1hYzZxMktJNmNCVzVlcyIsICJmYW1pbHlfbmFtZSIsICJNX`\
 `HUwMGY2Yml1cyJd`
  * No white space:\

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -1,5 +1,5 @@
 %%%
-title = "Selective Disclosure for JWTs (SD-JWT)"
+title = "SD-JWT: Selective Disclosure for JWT and JWS with JSON Payloads"
 abbrev = "SD-JWT"
 ipr = "trust200902"
 area = "Security"
@@ -1554,7 +1554,7 @@ data. The original JSON data is then used by the application. See
    * Added recommendation for explicit typing of SD-JWTs
    * Added considerations around forwarding credentials
    * Removed Example 2b and merged the demo of decoy digests into Example 2a
-   * Added some text to the Abstract and Introduction to be more inclusive of JWS with JSON
+   * Updated title to be more inclusive of JWS with JSON and added some corresponding text to the Abstract and Intro
    * Improved example for allowed variations in Disclosures
 
    -04

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -298,7 +298,7 @@ The array is created as follows:
 The resulting Disclosure would be: `WyJfMjZiYzRMVC1hYzZxMktJNmNCVzVlcyIsICJmYW1pbHlfbmFtZSIsICJNw7ZiaXVzIl0`
 
 Note that variations in whitespace, encoding of Unicode characters, ordering of object properties, etc., are allowed
-in the JSON representation and no canonicalization need be performed before base64url-encoding.
+in the JSON representation and no canonicalization needs be performed before base64url-encoding.
 For example, the following strings are all valid and encode the
 same claim value "Möbius":
 

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -1551,7 +1551,6 @@ data. The original JSON data is then used by the application. See
    * Removed Example 2b and merged the demo of decoy digests into Example 2a
    * Improved example for allowed variations in Disclosures
    * Added some text to the Abstract and Introduction to be more inclusive of JWS with JSON
-  
    -04
 
    * Improve description of processing of disclosures

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -1,5 +1,5 @@
 %%%
-title = "SD-JWT: Selective Disclosure for JWT and JWS with JSON Payloads"
+title = "Selective Disclosure for JWTs (SD-JWT)"
 abbrev = "SD-JWT"
 ipr = "trust200902"
 area = "Security"
@@ -1554,7 +1554,7 @@ data. The original JSON data is then used by the application. See
    * Added recommendation for explicit typing of SD-JWTs
    * Added considerations around forwarding credentials
    * Removed Example 2b and merged the demo of decoy digests into Example 2a
-   * Updated title to be more inclusive of JWS with JSON and added some corresponding text to the Abstract and Intro
+   * Added some text to the Abstract and Introduction to be more inclusive of JWS with JSON
    * Improved example for allowed variations in Disclosures
 
    -04

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -297,9 +297,9 @@ The array is created as follows:
 
 The resulting Disclosure would be: `WyJfMjZiYzRMVC1hYzZxMktJNmNCVzVlcyIsICJmYW1pbHlfbmFtZSIsICJNw7ZiaXVzIl0`
 
-Note that the JSON encoding of the object is not canonicalized, so variations in
-white space, encoding of Unicode characters, and ordering of object properties
-are allowed. For example, the following strings are all valid and encode the
+Note that variations in whitespace, encoding of Unicode characters, ordering of object properties, etc., are allowed
+in the JSON representation and no canonicalization need be performed before base64url-encoding.
+For example, the following strings are all valid and encode the
 same claim value "Möbius":
 
  * A different way to encode the unicode umlaut:\


### PR DESCRIPTION
This solves Issue #299 by moving away from an example that wasn't ideal anyway (it encoded a different bytestring for the value Möbius).

The Disclosure JSON should be:

`["_26bc4LT-ac6q2KI6cBW5es", "family_name", "M\u00f6bius"]`