### PR TITLE
updates to enveloping and JSON serialization

### DIFF
--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -728,27 +728,6 @@ If any step fails, the Presentation is not valid and processing MUST be aborted.
 
 Otherwise, the processed SD-JWT payload can be passed to the application to be used for the intended purpose.
 
-# Enveloping SD-JWTs {#enveloping}
-
-In some applications or transport protocols, it is desirable to put an SD-JWT into an outer JWT container. For example, an implementation may envelope multiple credentials and presentations, independent of their format, in a JWT to enable application-layer encryption during transport.
-
-For such use cases, the SD-JWT SHOULD be transported as a single string. Key Binding MAY be achieved by signing the envelope JWT instead of including a separate Key Binding JWT in the SD-JWT.
-
-The following non-normative example shows an SD-JWT Presentation enveloped in a JWT:
-
-```
-{
-  "aud": "https://verifier.example.org",
-  "iat": 1580000000,
-  "nonce": "iRnRdKuu1AtLM4ltc16by2XF0accSeutUescRw6BWC14",
-  "_sd_jwt": "eyJhbGci...emhlaUJhZzBZ~eyJhb...dYALCGg~"
-}
-```
-
-Here, the SD-JWT is shown as the value of an `_sd_jwt` claim where `eyJhbGci...emhlaUJhZzBZ` represents the Issuer-signed JWT and `eyJhb...dYALCGg` represents a Disclosure. The SD-JWT does not contain a Key Binding JWT as the outer container can be signed instead.
-
-Other specifications or profiles of this specification may define alternative formats for transporting an SD-JWT that envelope multiple such objects into one object and provide Key Binding using means other than the Key Binding JWT.
-
 # JWS JSON Serialization {#json_serialization}
 
 This section describes an optional alternate format for SD-JWT using the JWS JSON Serialization from [@!RFC7515].
@@ -777,6 +756,27 @@ includes a Key Binding JWT and has selected to disclose `given_name`, `family_na
 
 <{{examples/json_serialization/sd_jwt_presentation.json}}
 
+
+# Enveloping SD-JWTs {#enveloping}
+
+In some applications or transport protocols, it is desirable to put an SD-JWT into an outer JWT container. For example, an implementation may envelope multiple credentials and presentations, independent of their format, in a JWT to enable application-layer encryption during transport.
+
+For such use cases, the SD-JWT SHOULD be transported as a single string. Key Binding MAY be achieved by signing the envelope JWT instead of including a separate Key Binding JWT in the SD-JWT.
+
+The following non-normative example shows an SD-JWT Presentation enveloped in a JWT:
+
+```
+{
+  "aud": "https://verifier.example.org",
+  "iat": 1580000000,
+  "nonce": "iRnRdKuu1AtLM4ltc16by2XF0accSeutUescRw6BWC14",
+  "_sd_jwt": "eyJhbGci...emhlaUJhZzBZ~eyJhb...dYALCGg~"
+}
+```
+
+Here, the SD-JWT is shown as the value of an `_sd_jwt` claim where `eyJhbGci...emhlaUJhZzBZ` represents the Issuer-signed JWT and `eyJhb...dYALCGg` represents a Disclosure. The SD-JWT does not contain a Key Binding JWT as the outer container can be signed instead.
+
+Other specifications or profiles of this specification may define alternative formats for transporting an SD-JWT that envelope multiple such objects into one object and provide Key Binding using means other than the Key Binding JWT.
 
 
 # Security Considerations {#security_considerations}

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -733,18 +733,22 @@ Otherwise, the processed SD-JWT payload can be passed to the application to be u
 This section describes an optional alternate format for SD-JWT using the JWS JSON Serialization from [@!RFC7515].
 
 For both the General and Flattened JSON Serialization, the SD-JWT is represented as a JSON object according
-to Section 7.2 of [@!RFC7515]. The disclosures (both for issuance and presentation) are included in the
-serialized JWS using the key `disclosures` at the top-level of the JSON object (the same level as the `payload` member). The
+to Section 7.2 of [@!RFC7515]. The disclosures (both for issuance and presentation) SHOULD be included in the
+serialized JWS using the member name `disclosures` at the top-level of the JSON object (the same level as the `payload` member). The
 value of the `disclosures` member is an array of strings where each element is an individual Disclosure
 as described in (#creating_disclosures). The Issuer includes a Disclosure for each selectively
 disclosable claim of the SD-JWT payload, whereas the Holder includes only the Disclosures
-selected for the given presentation. Additionally, for presentation with a Key Binding, the Holder adds
-the key `kb_jwt` at the top-level of the serialized JWS with a string value containing the
-Key Binding JWT as described in (#kb-jwt).
+selected for the given presentation.
+
+Alternative methods for conveying the disclosures MAY be used (such as including them in a `disclosures`
+member of an outer JSON structure also containing the JSON Serialized SD-JWT) as dictated by a specific
+application or transport protocol. However, the details of such approaches fall outside the scope of this
+specification.
 
 Verification of the JWS JSON serialized SD-JWT follows the same rules defined in (#verification),
-except that the SD-JWT does not need to be split into component parts, but disclosures and (if applicable)
-a Key Binding JWT can be found in the respective members of the JSON object.
+except that the SD-JWT does not need to be split into component parts, the disclosures
+can be found in the respective member of the JSON object (or elsewhere), and Key Binding (if applicable)
+will be provided by means not specifically defined in this specification.
 
 Using a payload similar to that from [Example 1](#example-1), the following is a non-normative example of
 a JWS JSON serialized SD-JWT from an Issuer with all the respective Disclosures.
@@ -752,7 +756,7 @@ a JWS JSON serialized SD-JWT from an Issuer with all the respective Disclosures.
 <{{examples/json_serialization/sd_jwt_issuance.json}}
 
 Below is a non-normative example of a presentation of the JWS JSON serialized SD-JWT, where the Holder
-includes a Key Binding JWT and has selected to disclose `given_name`, `family_name`, and `address`.
+has selected to disclose `given_name`, `family_name`, and `address`.
 
 <{{examples/json_serialization/sd_jwt_presentation.json}}
 

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -1557,6 +1557,7 @@ data. The original JSON data is then used by the application. See
    * More precise wording around storing artifacts with sensitive data
    * The claim name `_sd` or `...` must not be used in a disclosure.
    * Ensure claims that control validity are checked after decoding payload
+   * Update JSON Serialization to remove the kb_jwt member and allow for the disclosures to be conveyed elsewhere
 
    -05
 

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -763,11 +763,12 @@ has selected to disclose `given_name`, `family_name`, and `address`.
 
 # Enveloping SD-JWTs {#enveloping}
 
-In some applications or transport protocols, it is desirable to put an SD-JWT into an outer JWT container. For example, an implementation may envelope multiple credentials and presentations, independent of their format, in a JWT to enable application-layer encryption during transport.
+In some applications or transport protocols, it is desirable to encapsulate an SD-JWT into an outer JWT container. For example, an implementation may enclose multiple credentials and presentations, independent of their format, in a JWT to enable application-layer encryption during transport.
 
-For such use cases, the SD-JWT SHOULD be transported as a single string. Key Binding MAY be achieved by signing the envelope JWT instead of including a separate Key Binding JWT in the SD-JWT.
+For such use cases, a compact serialized SD-JWT SHOULD be included as a single string value and a JSON serialized SD-JWT SHOULD be included as a JSON object value. Key Binding MAY be achieved by signing the envelope JWT instead of including a separate Key Binding JWT.
 
-The following non-normative example shows an SD-JWT Presentation enveloped in a JWT:
+The following non-normative example payload shows a compact serialized SD-JWT Presentation enveloped in a JWT.
+The SD-JWT is shown as the value of an `_sd_jwt` claim where `eyJhbGci...emhlaUJhZzBZ` is the Issuer-signed JWT and `eyJhb...dYALCGg` is a Disclosure. The SD-JWT does not contain a Key Binding JWT as the outer container can be signed instead.
 
 ```
 {
@@ -778,9 +779,29 @@ The following non-normative example shows an SD-JWT Presentation enveloped in a 
 }
 ```
 
-Here, the SD-JWT is shown as the value of an `_sd_jwt` claim where `eyJhbGci...emhlaUJhZzBZ` represents the Issuer-signed JWT and `eyJhb...dYALCGg` represents a Disclosure. The SD-JWT does not contain a Key Binding JWT as the outer container can be signed instead.
+This next non-normative example payload shows a JSON serialized SD-JWT enveloped in a JWT.
+The JSON serialized SD-JWT appears as the value of an `_js_sd_jwt` claim and the disclosures are included separately as a top-level claim.
+Key Binding is achieved by the signature on the enclosing JWT.
 
-Other specifications or profiles of this specification may define alternative formats for transporting an SD-JWT that envelope multiple such objects into one object and provide Key Binding using means other than the Key Binding JWT.
+```
+{
+  "aud": "https://verifier.example.org",
+  "iat": 2813308004,
+  "nonce": "8z8z9X3jUtbthem84swFAzp4aqlHf-sCqQ6eM_qmpUQ",
+  "_js_sd_jwt": {
+    "protected": "eyJhbGciOiAiRVMyNTYifQ",
+    "payload": "eyJfc2QiOiBbIjRIQm42YUlZM1d0dUdHV1R4LX...1NiJ9",
+    "signature": "y_b8KFVc2GZ1n-...PKsjU3Q",
+  }
+  "disclosures": [
+    "WyI2SWo3dE0tYTVpVlBHYm9TNXRtdlZBIiwgImZhbWlseV9uYW1...vZSJd",
+    "WyJBSngtMDk1VlBycFR0TjRRTU9xUk9BIiwgImFkZHJlc3MiLC...iVVMifV0",
+    "WyJlbHVWNU9nM2dTTklJO...V9BIiwgImdpdmVuX25hbWUiLCAiSm9obiJd"
+ ]
+}
+```
+
+Other specifications or profiles of this specification may define alternative formats for transporting an SD-JWT that envelope multiple such SD-JWTs into one object and provide Key Binding using means other than the Key Binding JWT.
 
 
 # Security Considerations {#security_considerations}
@@ -1558,6 +1579,7 @@ data. The original JSON data is then used by the application. See
    * The claim name `_sd` or `...` must not be used in a disclosure.
    * Ensure claims that control validity are checked after decoding payload
    * Update JSON Serialization to remove the kb_jwt member and allow for the disclosures to be conveyed elsewhere
+   * Expand the Enveloping SD-JWTs section to also discuss enveloping JSON serialized SD-JWTs
 
    -05
 

--- a/examples/json_serialization/specification.yml
+++ b/examples/json_serialization/specification.yml
@@ -16,6 +16,6 @@ holder_disclosed_claims:
   family_name: true
   address: true
 
-key_binding: True
+key_binding: False
 
 serialization_format: "json"


### PR DESCRIPTION
-Update JSON Serialization to remove the kb_jwt member and allow for the disclosures to be conveyed elsewhere
-Expand the Enveloping SD-JWTs section to also discuss enveloping JSON serialized SD-JWTs
-Swap Enveloping SD-JWTs and JSON Serialization sections 

Editor's Copy from this PR:
https://drafts.oauth.net/oauth-selective-disclosure-jwt/bc/enveloping-n-serialization/draft-ietf-oauth-selective-disclosure-jwt.html#name-jws-json-serialization
https://drafts.oauth.net/oauth-selective-disclosure-jwt/bc/enveloping-n-serialization/draft-ietf-oauth-selective-disclosure-jwt.html#name-enveloping-sd-jwts