### PR TITLE
Add text on hash in KB-JWT

### DIFF
--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -30,7 +30,7 @@ jobs:
     - name: "Install SD-JWT tooling"
       run: |
         python3 -m pip install --upgrade pip
-        python3 -m pip install git+https://github.com/openwallet-foundation-labs/sd-jwt-python.git
+        python3 -m pip install git+https://github.com/openwallet-foundation-labs/sd-jwt-python.git@danielfett/kb-jwt-hash
 
     # Build the local examples
     - name: "Build local examples"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
     - name: "Install SD-JWT tooling"
       run: |
         python3 -m pip install --upgrade pip
-        python3 -m pip install git+https://github.com/openwallet-foundation-labs/sd-jwt-python.git
+        python3 -m pip install git+https://github.com/openwallet-foundation-labs/sd-jwt-python.git@danielfett/kb-jwt-hash
 
     # Build the local examples
     - name: "Build local examples"

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -226,10 +226,9 @@ Note: How the public key is included in SD-JWT is out of scope of this document.
 
 For presenting an SD-JWT to a Verifier that enforces Key Binding, the Holder
 creates a signed document, the Key Binding JWT as defined in (#kb-jwt), using
-its private key. This document contains some data provided by the Verifier, such
-as a nonce, to ensure the freshness of the signature, an audience value to
+its private key. This document contains a nonce to ensure the freshness of the signature, an audience value to
 indicate the intended audience for the document, and a hash that ensures the
-integrity of the data sent to the Verifier. Details of the format of Key Binding JWTs are
+integrity of the data sent from the Holder to the Verifier. Details of the format of Key Binding JWTs are
 described in (#kb-jwt).
 
 Note that there may be other ways to send a Key Binding JWT to the Verifier or for the Holder to prove possession of the key material included in an SD-JWT. In these cases, inclusion of the Key Binding JWT in the SD-JWT is not required.

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -1007,9 +1007,8 @@ but if it is not, Issuers need to support and Verifiers need to enforce Key Bind
 
 In a Presentation, the Issuer-signed JWT is integrity-protected by the Issuer's
 signature, and the Disclosures are integrity-protected by the digests included
-in the Issuer-signed JWT. However, without enforcing a Key Binding JWT as
-defined in (#kb-jwt), the integrity of the set of Disclosures the
-Holder disclosed is not ensured.
+in the Issuer-signed JWT. If used, the KB-JWT, besides proving Key Binding, protects the integrity of the
+set of Disclosures the Holder disclosed.
 
 ## Explicit Typing {#explicit_typing}
 

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -262,7 +262,7 @@ The serialized format for the SD-JWT is the concatenation of each part delineate
 The order of the tilde separated values MUST be the Issuer-signed JWT, followed by any number of Disclosures, and lastly the optional Key Binding JWT.
 In the case that there is no Key Binding JWT, the last element MUST be an empty string and the last separating tilde character MUST NOT be omitted.
 
-The Disclosures are linked to the SD-JWT payload through the
+The Disclosures are linked to the Issuer-signed JWT through the
 digest values included therein.
 
 When issuing to a Holder, the Issuer includes all the relevant Disclosures in the SD-JWT.
@@ -270,7 +270,7 @@ When issuing to a Holder, the Issuer includes all the relevant Disclosures in th
 When presenting to a Verifier, the Holder sends only the selected set of the Disclosures in the SD-JWT.
 
 The Holder MAY send any subset of the Disclosures to the Verifier, i.e.,
-none, multiple, or all Disclosures. For data that the Holder does not want to reveal
+none, some, or all Disclosures. For data that the Holder does not want to reveal
 to the Verifier, the Holder MUST NOT send Disclosures or reveal the salt values in any
 other way.
 

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -396,7 +396,7 @@ The SHA-256 digest of the Disclosure
 
 ### Embedding Disclosure Digests in SD-JWTs {#embedding_disclosure_digests}
 
-For selectively disclosable claims, the digests of the Disclosures are embedded into the SD-JWT instead of the claims themselves. The precise way of embedding depends on whether a claim is an object property (key-value pair) or an array element.
+For selectively disclosable claims, the digests of the Disclosures are embedded into the Issuer-signed JWT instead of the claims themselves. The precise way of embedding depends on whether a claim is an object property (key-value pair) or an array element.
 
  * For a claim that is an object property, the Issuer embeds a Disclosure as described in (#embedding_object_properties).
 * For a claim that is an array element, the Issuer creates a Disclosure as described in (#embedding_array_elements).

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -1008,7 +1008,7 @@ but if it is not, Issuers need to support and Verifiers need to enforce Key Bind
 In a Presentation, the Issuer-signed JWT is integrity-protected by the Issuer's
 signature, and the Disclosures are integrity-protected by the digests included
 in the Issuer-signed JWT. However, without enforcing a Key Binding JWT as
-defined in (#kb-jwt), the integrity of the set of Disclosures the 
+defined in (#kb-jwt), the integrity of the set of Disclosures the
 Holder selected to send is not ensured.
 
 ## Explicit Typing {#explicit_typing}

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -524,7 +524,7 @@ The JWT MUST contain the following elements:
     * `nonce`: REQUIRED. Ensures the freshness of the signature. The value type of this claim MUST be a string. How this value is obtained is up to the protocol used and out of scope of this specification.
     * `_sd_hash`: REQUIRED. The base64url-encoded hash digest over the Issuer-signed JWT and the selected Disclosures as defined below.
 
-### Integrity Protection of the Presentation
+### Integrity Protection of the Presentation {#integrity-protection-of-the-presentation}
 
 The hash digest in `_sd_hash` ensures the integrity of the Presentation. It MUST
 be taken over the US-ASCII bytes preceding the KB-JWT in the Presentation, i.e.,
@@ -744,7 +744,7 @@ To this end, Verifiers MUST follow the following steps (or equivalent):
        5. Check that the `typ` of the Key Binding JWT is `kb+jwt`.
        6. Check that the creation time of the Key Binding JWT, as determined by the `iat` claim, is within an acceptable window.
        7. Determine that the Key Binding JWT is bound to the current transaction and was created for this Verifier (replay protection) by validating `nonce` and `aud` claims.
-       8. Calculate the digest over the Presentation and verify that it matches the value of the `_sd_hash` claim in the Key Binding JWT.
+       8. Calculate the digest over the Issuer-signed JWT and Disclosures as defined in (#integrity-protection-of-the-presentation) and verify that it matches the value of the `_sd_hash` claim in the Key Binding JWT.
        9. Check that the Key Binding JWT is valid in all other respects, per [@!RFC7519] and [@!RFC8725].
 
 If any step fails, the Presentation is not valid and processing MUST be aborted.

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -1006,9 +1006,13 @@ but if it is not, Issuers need to support and Verifiers need to enforce Key Bind
 
 ## Integrity of Presentation
 
-Without a Key Binding JWT as defined in (#kb-jwt), the integrity of the
-Presentation is not protected, i.e., an attacker that can intercept the
-Presentation can remove Disclosures or add new ones.
+In a Presentation, the Issuer-signed JWT is integrity-protected by the Issuer's
+signature, and the Disclosures are integrity-protected by the digests included
+in the Issuer-signed JWT. However, without enforcing a Key Binding JWT as
+defined in (#kb-jwt), an attacker that can intercept the Presentation can remove
+Disclosures. The attacker could in theory also add Disclosures, but that would
+require the attacker to know the salt and claim value for the claim to be added,
+which is infeasible if the salt has sufficient entropy.
 
 ## Explicit Typing {#explicit_typing}
 

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -1183,9 +1183,16 @@ IANA "JSON Web Token Claims" registry [@IANA.JWT] established by [@!RFC7519].
 <br/>
 
 *  Claim Name: `_sd_alg`
-*  Claim Description: Hash algorithm used to generate disclosure digests
+*  Claim Description: Hash algorithm used to generate disclosure digests and digest over presentation
 *  Change Controller: IETF
 *  Specification Document(s):  [[ (#hash_function_claim) of this specification ]]
+
+<br/>
+
+*  Claim Name: `_sd_hash`
+*  Claim Description: Digest of the Issuer-signed JWT and Disclosures in a Presentation
+*  Change Controller: IETF
+*  Specification Document(s):  [[ (#kb-jwt) of this specification ]]
 
 ## Media Type Registration
 

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -1009,7 +1009,7 @@ In a Presentation, the Issuer-signed JWT is integrity-protected by the Issuer's
 signature, and the Disclosures are integrity-protected by the digests included
 in the Issuer-signed JWT. However, without enforcing a Key Binding JWT as
 defined in (#kb-jwt), the integrity of the set of Disclosures the
-Holder selected to send is not ensured.
+Holder disclosed is not ensured.
 
 ## Explicit Typing {#explicit_typing}
 

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -525,8 +525,8 @@ The JWT MUST contain the following elements:
 
 ### Integrity Protection of the Presentation
 
-The hash digest in `_sd_hash` ensures the integrity of the presentation. It MUST
-be taken over the US-ASCII bytes preceding the KB-JWT in the presentation, i.e.,
+The hash digest in `_sd_hash` ensures the integrity of the Presentation. It MUST
+be taken over the US-ASCII bytes preceding the KB-JWT in the Presentation, i.e.,
 the Issuer-signed JWT, a tilde character, and zero or more Disclosures selected
 for presentation to the Verifier, each followed by a tilde character:
 
@@ -743,7 +743,7 @@ To this end, Verifiers MUST follow the following steps (or equivalent):
        5. Check that the `typ` of the Key Binding JWT is `kb+jwt`.
        6. Check that the creation time of the Key Binding JWT, as determined by the `iat` claim, is within an acceptable window.
        7. Determine that the Key Binding JWT is bound to the current transaction and was created for this Verifier (replay protection) by validating `nonce` and `aud` claims.
-       8. Calculate the digest over the presentation and verify that it matches the value of the `_sd_hash` claim in the Key Binding JWT.
+       8. Calculate the digest over the Presentation and verify that it matches the value of the `_sd_hash` claim in the Key Binding JWT.
        9. Check that the Key Binding JWT is valid in all other respects, per [@!RFC7519] and [@!RFC8725].
 
 If any step fails, the Presentation is not valid and processing MUST be aborted.

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -224,11 +224,13 @@ Key Binding is an optional feature. When Key Binding is required by the use-case
 
 Note: How the public key is included in SD-JWT is out of scope of this document. It can be passed by value or by reference.
 
-The Holder can then create a signed document, the Key Binding JWT as defined in (#kb-jwt), using its private key. This document contains some
-data provided by the Verifier such as a nonce to ensure the freshness of the signature, and audience to indicate the
-intended audience for the document.
-
-The Key Binding JWT can be included as part of the SD-JWT and sent to the Verifier as described in (#data_formats).
+For presenting an SD-JWT to a Verifier that enforces Key Binding, the Holder
+creates a signed document, the Key Binding JWT as defined in (#kb-jwt), using
+its private key. This document contains some data provided by the Verifier, such
+as a nonce, to ensure the freshness of the signature, an audience value to
+indicate the intended audience for the document, and a hash that ensures the
+integrity of the data sent to the Verifier. Details of the format of Key Binding JWTs are
+described in (#kb-jwt).
 
 Note that there may be other ways to send a Key Binding JWT to the Verifier or for the Holder to prove possession of the key material included in an SD-JWT. In these cases, inclusion of the Key Binding JWT in the SD-JWT is not required.
 

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -471,15 +471,6 @@ The JWT MUST contain the following elements:
 
 To validate the signature on the Key Binding JWT, the Verifier MUST use the key material in the SD-JWT. If it is not clear from the SD-JWT, the Key Binding JWT MUST specify which key material the Verifier needs to use to validate the Key Binding JWT signature using JOSE header parameters such as `kid` and `x5c`.
 
-Below is a non-normative example of a Key Binding JWT header:
-
-```
-{
-  "alg": "ES256",
-  "typ": "kb+jwt"
-}
-```
-
 Whether to require Key Binding is up to the Verifier's policy, based on the set
 of trust requirements such as trust frameworks it belongs to. See
 (#key_binding_security) for security considerations.

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -289,9 +289,11 @@ The payload of an SD-JWT is a JSON object according to the following rules:
  2. The payload MAY contain one or more digests of Disclosures to enable selective disclosure of the respective claims, created and formatted as described in (#creating_disclosures).
  3. The payload MAY contain one or more decoy digests to obscure the actual number of claims in the SD-JWT, created and formatted as described in (#decoy_digests).
  4. The payload MAY contain one or more non-selectively disclosable claims.
- 5. The payload MAY also contain Holder's public key(s) or reference(s) thereto, as well as further claims such as `iss`, `iat`, etc. as defined or required by the application using SD-JWTs. See (#holder_public_key_claim) for more details.
- 6. The payload MUST NOT contain the reserved claims `_sd` or `...` except for the purpose of transporting digests as described below.
- 7. The same digest value MUST NOT appear more than once in the SD-JWT.
+ 5. The payload MAY contain the Holder's public key(s) or reference(s) thereto, as explained in (#holder_public_key_claim).
+ 6. The payload MAY contain further claims such as `iss`, `iat`, etc. as defined or required by the application using SD-JWTs.
+ 7. The payload MUST NOT contain the reserved claims `_sd` or `...` except for the purpose of transporting digests as described below.
+
+The same digest value MUST NOT appear more than once in the SD-JWT.
 
 Applications of SD-JWT SHOULD be explicitly typed using the `typ` header parameter. See (#explicit_typing) for more details.
 
@@ -430,8 +432,8 @@ The SHA-256 digest of the Disclosure
 
 For selectively disclosable claims, the digests of the Disclosures are embedded into the Issuer-signed JWT instead of the claims themselves. The precise way of embedding depends on whether a claim is an object property (key-value pair) or an array element.
 
- * For a claim that is an object property, the Issuer embeds a Disclosure as described in (#embedding_object_properties).
-* For a claim that is an array element, the Issuer creates a Disclosure as described in (#embedding_array_elements).
+ * For a claim that is an object property, the Issuer embeds a Disclosure digest as described in (#embedding_object_properties).
+ * For a claim that is an array element, the Issuer creates a Disclosure digest as described in (#embedding_array_elements).
 
 #### Object Properties {#embedding_object_properties}
 
@@ -535,6 +537,10 @@ signed JWT. See (#enveloping) for details.
 
 In this example, a simple SD-JWT is demonstrated. This example is split into issuance and presentation.
 
+Note: Throughout the examples in this document, line breaks had to be added to
+JSON strings and base64-encoded strings to adhere to the 72 character limit for
+lines in RFCs and for readability. JSON does not allow line breaks within strings.
+
 ## Issuance
 
 The Issuer is using the following input claim set:
@@ -562,7 +568,7 @@ The payload is then signed by the Issuer to create a JWT like the following:
 
 <{{examples/simple/sd_jwt_jws_part.txt}}
 
-The issued SD-JWT might look as follows (with Line breaks for formatting only):
+The issued SD-JWT might look as follows:
 
 <{{examples/simple/sd_jwt_issuance.txt}}
 
@@ -598,11 +604,6 @@ The following input claim set is used as an example throughout this section:
 Important: The following examples of the structures are non-normative and are not intended to
 represent all possible options. They are also not meant to define or restrict
 how `address` can be represented in an SD-JWT.
-
-Note: Throughout the examples in this document, line breaks had to
-be added to JSON strings and base64-encoded strings (as shown in the
-next example) to adhere to the 72 character limit for lines in RFCs and
-for readability. JSON does not allow line breaks in strings.
 
 ## Example: Flat SD-JWT
 
@@ -1443,7 +1444,7 @@ The Issuer is using the following input claim set:
 
 <{{examples/arf-pid/user_claims.json}}
 
-The following is the issued SD-JWT (with line breaks for formatting only):
+The following is the issued SD-JWT:
 
 <{{examples/arf-pid/sd_jwt_issuance.txt}}
 
@@ -1479,7 +1480,7 @@ The Issuer is using the following input claim set:
 
 <{{examples/jsonld/user_claims.json}}
 
-The following is the issued SD-JWT (with line breaks for formatting only):
+The following is the issued SD-JWT:
 
 <{{examples/jsonld/sd_jwt_issuance.txt}}
 

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -256,6 +256,7 @@ The serialized format for the SD-JWT is the concatenation of each part delineate
 
 ```
 <Issuer-signed JWT>~<Disclosure 1>~<Disclosure 2>~...~<Disclosure N>~<optional KB-JWT>
+
 ```
 
 The order of the tilde separated values MUST be the Issuer-signed JWT, followed by any number of Disclosures, and lastly the optional Key Binding JWT.

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -210,7 +210,7 @@ conceptual level, abstracting from the data formats described in (#data_formats)
 
 An SD-JWT, at its core, is a digitally signed JSON document containing digests over the selectively disclosable claims with the Disclosures outside the document. Disclosures can be omitted without breaking the signature, and modifying them can be detected. Selectively disclosable claims can be individual object properties (key-value pairs) or array elements.
 
-Each digest value ensures the integrity of, and maps to, the respective Disclosure.  Digest values are calculated using a hash function over the Disclosures, each of which contains a cryptographically secure random salt, the claim name (only when the claim is an object property), and the claim value. The Disclosures are sent to the Holder as part of the SD-JWT in the format defined in (#sd-jwt-structure).
+Each digest value ensures the integrity of, and maps to, the respective Disclosure.  Digest values are calculated using a hash function over the Disclosures, each of which contains a cryptographically secure random salt, the claim name (only when the claim is an object property), and the claim value. The Disclosures are sent to the Holder as part of the SD-JWT in the format defined in (#data_formats).
 
 An SD-JWT MAY also contain clear-text claims that are always disclosed to the Verifier.
 
@@ -228,7 +228,7 @@ The Holder can then create a signed document, the Key Binding JWT as defined in 
 data provided by the Verifier such as a nonce to ensure the freshness of the signature, and audience to indicate the
 intended audience for the document.
 
-The Key Binding JWT can be included as part of the SD-JWT and sent to the Verifier as described in (#sd-jwt-structure).
+The Key Binding JWT can be included as part of the SD-JWT and sent to the Verifier as described in (#data_formats).
 
 Note that there may be other ways to send a Key Binding JWT to the Verifier or for the Holder to prove possession of the key material included in an SD-JWT. In these cases, inclusion of the Key Binding JWT in the SD-JWT is not required.
 

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -533,7 +533,12 @@ for presentation to the Verifier, each followed by a tilde character:
 ```
 <Issuer-signed JWT>~<Disclosure 1>~<Disclosure 2>~...~<Disclosure N>~
 ```
+
 The bytes of the digest MUST then be base64url-encoded.
+
+The same hash algorithm as for the Disclosures MUST be used (defined by
+the `_sd_alg` element in the Issuer-signed JWT or the default value, as defined
+in (#hash_function_claim)).
 
 ### Validating the Key Binding JWT
 
@@ -738,7 +743,8 @@ To this end, Verifiers MUST follow the following steps (or equivalent):
        5. Check that the `typ` of the Key Binding JWT is `kb+jwt`.
        6. Check that the creation time of the Key Binding JWT, as determined by the `iat` claim, is within an acceptable window.
        7. Determine that the Key Binding JWT is bound to the current transaction and was created for this Verifier (replay protection) by validating `nonce` and `aud` claims.
-       8. Check that the Key Binding JWT is valid in all other respects, per [@!RFC7519] and [@!RFC8725].
+       8. Calculate the digest over the presentation and verify that it matches the value of the `_sd_hash` claim in the Key Binding JWT.
+       9. Check that the Key Binding JWT is valid in all other respects, per [@!RFC7519] and [@!RFC8725].
 
 If any step fails, the Presentation is not valid and processing MUST be aborted.
 

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -1653,6 +1653,7 @@ data. The original JSON data is then used by the application. See
 
    -06
 
+   * Added hash of Issuer-signed part and Disclosures in KB-JWT
    * Fix minor issues in some examples
    * Added IANA media type registration request for the JSON Serialization
    * More precise wording around storing artifacts with sensitive data

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -242,11 +242,42 @@ At a high level, the Verifier
 
 The detailed algorithm is described in (#verifier_verification).
 
-# Data Formats {#data_formats}
+# SD-JWT Data Formats {#data_formats}
 
-This section defines data formats for SD-JWT including the Issuer-signed JWT content, Disclosures, and Key Binding JWT.
+An SD-JWT is composed of the following:
 
-## SD-JWT Payload
+* an Issuer-signed JWT,
+* zero or more Disclosures, and
+* optionally a Key Binding JWT.
+
+The individual parts will be explained in the following subsections.
+
+The serialized format for the SD-JWT is the concatenation of each part delineated with a single tilde ('~') character as follows:
+
+```
+<Issuer-signed JWT>~<Disclosure 1>~<Disclosure 2>~...~<Disclosure N>~<optional KB-JWT>
+```
+
+The order of the tilde separated values MUST be the Issuer-signed JWT, followed by any number of Disclosures, and lastly the optional Key Binding JWT.
+In the case that there is no Key Binding JWT, the last element MUST be an empty string and the last separating tilde character MUST NOT be omitted.
+
+The Disclosures are linked to the SD-JWT payload through the
+digest values included therein.
+
+When issued to a Holder, the Issuer includes all the relevant Disclosures in the SD-JWT.
+
+For presentation to a Verifier, the Holder sends the SD-JWT including only its selected
+set of the Disclosures to the Verifier.
+
+The Holder MAY send any subset of the Disclosures to the Verifier, i.e.,
+none, multiple, or all Disclosures. For data that the Holder does not want to reveal
+to the Verifier, the Holder MUST NOT send Disclosures or reveal the salt values in any
+other way.
+
+A Holder MUST NOT send a Disclosure that was not included in the SD-JWT or send
+a Disclosure more than once.
+
+## Issuer-signed JWT Payload
 
 An SD-JWT has a JWT component that MUST be signed using the Issuer's private key.
 It MUST use a JWS asymmetric digital signature algorithm. It
@@ -258,7 +289,7 @@ The payload of an SD-JWT is a JSON object according to the following rules:
  2. The payload MAY contain one or more digests of Disclosures to enable selective disclosure of the respective claims, created and formatted as described below.
  3. The payload MAY contain one or more decoy digests to obscure the actual number of claims in the SD-JWT, created and formatted as described in (#decoy_digests).
  4. The payload MAY contain one or more non-selectively disclosable claims.
- 5. The payload MAY also contain Holder's public key(s) or reference(s) thereto, as well as further claims such as `iss`, `iat`, etc. as defined or required by the application using SD-JWTs.
+ 5. The payload MAY also contain Holder's public key(s) or reference(s) thereto, as well as further claims such as `iss`, `iat`, etc. as defined or required by the application using SD-JWTs. See (#holder_public_key_claim) for more details.
  6. The payload MUST NOT contain the reserved claims `_sd` or `...` except for the purpose of transporting digests as described below.
  7. The same digest value MUST NOT appear more than once in the SD-JWT.
 
@@ -269,7 +300,7 @@ It is the Issuer who decides which claims are selectively disclosable and which 
 Claims that are not selectively disclosable are included in the SD-JWT in plaintext just as they would be in any other JSON structure.
 
 
-## Creating Disclosures {#creating_disclosures}
+## Disclosures {#creating_disclosures}
 
 Disclosures are created differently depending on whether a claim is an object property (key-value pair) or an array element.
 
@@ -344,7 +375,7 @@ could be created by first creating the following array:
 
 The resulting Disclosure would be: `WyJsa2x4RjVqTVlsR1RQVW92TU5JdkNBIiwgIkZSIl0`
 
-## Hashing Disclosures {#hashing_disclosures}
+### Hashing Disclosures {#hashing_disclosures}
 
 For embedding the Disclosures in the SD-JWT, the Disclosures are hashed using the hash algorithm specified in the `_sd_alg` claim described in (#hash_function_claim). The resulting digest is then included in the SD-JWT payload instead of the original claim value, as described next.
 
@@ -363,14 +394,14 @@ The SHA-256 digest of the Disclosure
 `WyJsa2x4RjVqTVlsR1RQVW92TU5JdkNBIiwgIkZSIl0` would be
 `w0I8EKcdCtUPkGCNUrfwVp2xEgNjtoIDlOxc9-PlOhs`.
 
-## Embedding Disclosure Digests in SD-JWTs {#embedding_disclosure_digests}
+### Embedding Disclosure Digests in SD-JWTs {#embedding_disclosure_digests}
 
 For selectively disclosable claims, the digests of the Disclosures are embedded into the SD-JWT instead of the claims themselves. The precise way of embedding depends on whether a claim is an object property (key-value pair) or an array element.
 
  * For a claim that is an object property, the Issuer embeds a Disclosure as described in (#embedding_object_properties).
 * For a claim that is an array element, the Issuer creates a Disclosure as described in (#embedding_array_elements).
 
-### Object Properties {#embedding_object_properties}
+#### Object Properties {#embedding_object_properties}
 
 Digests of Disclosures for object properties are added to an array under the new
 key `_sd` in the object. The `_sd` key MUST refer to an array of strings, each
@@ -397,7 +428,7 @@ selectively disclosable:
 }
 ```
 
-### Array Elements {#embedding_array_elements}
+#### Array Elements {#embedding_array_elements}
 
 Digests of Disclosures for array elements are added to the array in the same
 position as the original claim value in the array. For each digest, an object
@@ -422,9 +453,47 @@ disclosable array elements for which they did not receive a Disclosure. In the
 example above, the verification process would output an array with only one
 element unless a matching Disclosure for the second element is received.
 
-## Example 1: SD-JWT {#example-1}
 
-In this example, a simple SD-JWT is demonstrated.
+## Key Binding JWT {#kb-jwt}
+
+This section defines the contents of the optional Key Binding JWT, which
+the Holder MAY include in the SD-JWT to prove the Key Binding to the Verifier.
+
+The JWT MUST contain the following elements:
+
+* in the JOSE header,
+    * `typ`: REQUIRED. MUST be `kb+jwt`, which explicitly types the Key Binding JWT as recommended in Section 3.11 of [@!RFC8725].
+    * `alg`: REQUIRED. A digital signature algorithm identifier such as per IANA "JSON Web Signature and Encryption Algorithms" registry. MUST NOT be `none` or an identifier for a symmetric algorithm (MAC).
+* in the JWT payload,
+    * `iat`: REQUIRED. The value of this claim MUST be the time at which the Key Binding JWT was issued using the syntax defined in [@!RFC7519].
+    * `aud`: REQUIRED. The intended receiver of the Key Binding JWT. How the value is represented is up to the protocol used and out of scope of this specification.
+    * `nonce`: REQUIRED. Ensures the freshness of the signature. The value type of this claim MUST be a string. How this value is obtained is up to the protocol used and out of scope of this specification.
+
+To validate the signature on the Key Binding JWT, the Verifier MUST use the key material in the SD-JWT. If it is not clear from the SD-JWT, the Key Binding JWT MUST specify which key material the Verifier needs to use to validate the Key Binding JWT signature using JOSE header parameters such as `kid` and `x5c`.
+
+Below is a non-normative example of a Key Binding JWT header:
+
+```
+{
+  "alg": "ES256",
+  "typ": "kb+jwt"
+}
+```
+
+Whether to require Key Binding is up to the Verifier's policy, based on the set
+of trust requirements such as trust frameworks it belongs to. See
+(#key_binding_security) for security considerations.
+
+Other ways of proving Key Binding MAY be used when supported by the Verifier,
+e.g., when the presented SD-JWT without a Key Binding JWT is itself embedded in a
+signed JWT. See (#enveloping) for details.
+
+
+# Example 1: SD-JWT {#example-1}
+
+In this example, a simple SD-JWT is demonstrated. This example is split into issuance and presentation.
+
+## Issuance
 
 The Issuer is using the following input claim set:
 
@@ -451,25 +520,25 @@ The payload is then signed by the Issuer to create a JWT like the following:
 
 <{{examples/simple/sd_jwt_jws_part.txt}}
 
-## Decoy Digests {#decoy_digests}
+The issued SD-JWT might look as follows (with Line breaks for formatting only):
 
-An Issuer MAY add additional digests to the SD-JWT payload that are not associated with
-any claim.  The purpose of such "decoy" digests is to make it more difficult for
-an attacker to see the original number of claims contained in the SD-JWT. Decoy
-digests MAY be added both to the `_sd` array for objects as well as in arrays.
+<{{examples/simple/sd_jwt_issuance.txt}}
 
-It is RECOMMENDED to create the decoy digests by hashing over a
-cryptographically secure random number. The bytes of the digest MUST then be
-base64url-encoded as above. The same digest function as for the Disclosures MUST
-be used.
+## Presentation
 
-For decoy digests, no Disclosure is sent to the Holder, i.e., the Holder will
-see digests that do not correspond to any Disclosure. See
-(#decoy_digests_privacy) for additional privacy considerations.
+The following non-normative example shows an associated SD-JWT Presentation as
+it would be sent from the Holder to the Verifier. Note that it consists of six
+`~`-separated parts, with the Issuer-signed JWT as shown above in the beginning,
+four Disclosures (for the claims `given_name`, `family_name`, `address`, and
+`nationalities`) in the middle, and the Key Binding JWT as the last element.
 
-To ensure readability and replicability, the examples in this specification do
-not contain decoy digests unless explicitly stated. For an example
-with decoy digests, see (#example-simple_structured).
+<{{examples/simple/sd_jwt_presentation.txt}}
+
+The following Key Binding JWT payload was created and signed for this presentation by the Holder:
+
+<{{examples/simple/kb_jwt_payload.json}}
+
+# Data Format Details
 
 ## Nested Data in SD-JWTs {#nested_data}
 
@@ -531,6 +600,26 @@ The Issuer creates Disclosures first for the sub-claims and then includes their 
 
 {{examples/address_only_recursive/disclosures.md}}
 
+## Decoy Digests {#decoy_digests}
+
+An Issuer MAY add additional digests to the SD-JWT payload that are not associated with
+any claim.  The purpose of such "decoy" digests is to make it more difficult for
+an attacker to see the original number of claims contained in the SD-JWT. Decoy
+digests MAY be added both to the `_sd` array for objects as well as in arrays.
+
+It is RECOMMENDED to create the decoy digests by hashing over a
+cryptographically secure random number. The bytes of the digest MUST then be
+base64url-encoded as above. The same digest function as for the Disclosures MUST
+be used.
+
+For decoy digests, no Disclosure is sent to the Holder, i.e., the Holder will
+see digests that do not correspond to any Disclosure. See
+(#decoy_digests_privacy) for additional privacy considerations.
+
+To ensure readability and replicability, the examples in this specification do
+not contain decoy digests unless explicitly stated. For an example
+with decoy digests, see (#example-simple_structured).
+
 ## Hash Function Claim {#hash_function_claim}
 
 The claim `_sd_alg` indicates the hash algorithm used by the Issuer to generate
@@ -562,89 +651,6 @@ Holder and Issuer MAY use pre-established key material.
 
 Note: The examples in this document use the `cnf` claim defined in [@RFC7800] to include
 the raw public key by value in SD-JWT.
-
-## Key Binding JWT {#kb-jwt}
-
-This section defines the contents of the Key Binding JWT, which
-the Holder MAY include in the SD-JWT to prove the Key Binding to the Verifier.
-
-The JWT MUST contain the following elements:
-
-* in the JOSE header,
-    * `typ`: REQUIRED. MUST be `kb+jwt`, which explicitly types the Key Binding JWT as recommended in Section 3.11 of [@!RFC8725].
-    * `alg`: REQUIRED. A digital signature algorithm identifier such as per IANA "JSON Web Signature and Encryption Algorithms" registry. MUST NOT be `none` or an identifier for a symmetric algorithm (MAC).
-* in the JWT payload,
-    * `iat`: REQUIRED. The value of this claim MUST be the time at which the Key Binding JWT was issued using the syntax defined in [@!RFC7519].
-    * `aud`: REQUIRED. The intended receiver of the Key Binding JWT. How the value is represented is up to the protocol used and out of scope of this specification.
-    * `nonce`: REQUIRED. Ensures the freshness of the signature. The value type of this claim MUST be a string. How this value is obtained is up to the protocol used and out of scope of this specification.
-
-To validate the signature on the Key Binding JWT, the Verifier MUST use the key material in the SD-JWT. If it is not clear from the SD-JWT, the Key Binding JWT MUST specify which key material the Verifier needs to use to validate the Key Binding JWT signature using JOSE header parameters such as `kid` and `x5c`.
-
-Below is a non-normative example of a Key Binding JWT header:
-
-```
-{
-  "alg": "ES256",
-  "typ": "kb+jwt"
-}
-```
-
-Below is a non-normative example of a Key Binding JWT payload:
-
-<{{examples/simple/kb_jwt_payload.json}}
-
-Below is a non-normative example of a Key Binding JWT produced by signing a payload in the example above:
-
-<{{examples/simple/kb_jwt_serialized.txt}}
-
-Whether to require Key Binding is up to the Verifier's policy,
-based on the set of trust requirements such as trust frameworks it belongs to.
-
-Other ways of proving Key Binding MAY be used when supported by the Verifier,
-e.g., when the presented SD-JWT without a Key Binding JWT is itself embedded in a
-signed JWT. See (#enveloping) for details.
-
-## SD-JWT Structure {#sd-jwt-structure}
-
-An SD-JWT is composed of the following:
-
-* the Issuer-signed JWT
-* zero or more Disclosures
-* optionally a Key Binding JWT
-
-The serialized format for the SD-JWT is the concatenation of each part delineated with a single tilde ('~') character as follows:
-
-```
-<JWT>~<Disclosure 1>~<Disclosure 2>~...~<Disclosure N>~<optional KB-JWT>
-```
-
-The order of the tilde separated values MUST be the Issuer-signed JWT, followed by any Disclosures, and lastly the optional Key Binding JWT.
-In the case that there is no Key Binding JWT, the last element MUST be an empty string and the last separating tilde character MUST NOT be omitted.
-
-The Disclosures are linked to the SD-JWT payload through the
-digest values included therein.
-
-When issued to a Holder, the Issuer includes all the relevant Disclosures in the SD-JWT.
-
-For presentation to a Verifier, the Holder sends the SD-JWT including only its selected
-set of the Disclosures to the Verifier.
-
-The Holder MAY send any subset of the Disclosures to the Verifier, i.e.,
-none, multiple, or all Disclosures. For data that the Holder does not want to reveal
-to the Verifier, the Holder MUST NOT send Disclosures or reveal the salt values in any
-other way.
-
-A Holder MUST NOT send a Disclosure that was not included in the SD-JWT or send
-a Disclosure more than once.
-
-For [Example 1](#example-1), a non-normative example of an issued SD-JWT might look as follows (with Line breaks for formatting only):
-
-<{{examples/simple/sd_jwt_issuance.txt}}
-
-The following non-normative example shows an associated SD-JWT Presentation as it would be sent from the Holder to the Verifier.
-The claims `given_name`, `family_name`, and `address` are disclosed and the Key Binding JWT is included as the last element.
-
-<{{examples/simple/sd_jwt_presentation.txt}}
 
 # Verification and Processing {#verification}
 
@@ -1554,6 +1560,7 @@ data. The original JSON data is then used by the application. See
    * More precise wording around storing artifacts with sensitive data
    * The claim name `_sd` or `...` must not be used in a disclosure.
    * Ensure claims that control validity are checked after decoding payload
+   * Restructure sections around data formats and Example 1
 
    -05
 

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -1009,10 +1009,8 @@ but if it is not, Issuers need to support and Verifiers need to enforce Key Bind
 In a Presentation, the Issuer-signed JWT is integrity-protected by the Issuer's
 signature, and the Disclosures are integrity-protected by the digests included
 in the Issuer-signed JWT. However, without enforcing a Key Binding JWT as
-defined in (#kb-jwt), an attacker that can intercept the Presentation can remove
-Disclosures. The attacker could in theory also add Disclosures, but that would
-require the attacker to know the salt and claim value for the claim to be added,
-which is infeasible if the salt has sufficient entropy.
+defined in (#kb-jwt), the integrity of the set of Disclosures the 
+Holder selected to send is not ensured.
 
 ## Explicit Typing {#explicit_typing}
 

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -265,10 +265,9 @@ In the case that there is no Key Binding JWT, the last element MUST be an empty 
 The Disclosures are linked to the SD-JWT payload through the
 digest values included therein.
 
-When issued to a Holder, the Issuer includes all the relevant Disclosures in the SD-JWT.
+When issuing to a Holder, the Issuer includes all the relevant Disclosures in the SD-JWT.
 
-For presentation to a Verifier, the Holder sends the SD-JWT including only its selected
-set of the Disclosures to the Verifier.
+When presenting to a Verifier, the Holder sends only the selected set of the Disclosures in the SD-JWT.
 
 The Holder MAY send any subset of the Disclosures to the Verifier, i.e.,
 none, multiple, or all Disclosures. For data that the Holder does not want to reveal


### PR DESCRIPTION
Fixes Issue #346 

Let's discuss whether we want to make the hash REQUIRED, OPTIONAL or RECOMMENDED. Current text is for REQUIRED. I'm leaning towards that in order to reduce optionality. It also means that there will be less situations where a Verifier accidentally accepts a KB-JWT without the hash (and we don't need to discuss mitigations against that).