### PR TITLE
be more explicit that VC examples do not define anything

### DIFF
--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -1456,7 +1456,11 @@ the media type is encoded as an SD-JWT.
 
 # Additional Examples
 
-All of the following examples are non-normative.
+Important: The following examples are not normative and provided for
+illustrative purposes only. In particular, neither the structure of the claims
+nor the selection of selectively disclosable claims are normative.
+
+Line breaks have been added for readability.
 
 ## Example 2: Handling Structured Claims {#example-simple_structured}
 

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -1456,7 +1456,7 @@ the media type is encoded as an SD-JWT.
 
 # Additional Examples
 
-Important: The following examples are not normative and provided for
+Important: The following examples are not normative and are provided for
 illustrative purposes only. In particular, neither the structure of the claims
 nor the selection of selectively disclosable claims is normative.
 

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -1567,9 +1567,10 @@ After the validation, the Verifier will have the following data for further proc
 
 ## Example 4a - SD-JWT-based Verifiable Credentials (SD-JWT VC)
 
-In this example, the artifacts defined in this specification are used to represent
-SD-JWT-based Verifiable Credentials (SD-JWT VC) as defined in [@I-D.ietf-oauth-sd-jwt-vc].
-Person Identification Data (PID) defined in [@EUDIW.ARF] is used.
+This example shows how the artifacts defined in this specification
+could hypothetically be used to express an
+SD-JWT-based Verifiable Credential [@I-D.ietf-oauth-sd-jwt-vc] with
+Person Identification Data (PID) defined in [@EUDIW.ARF].
 
 Key Binding is applied
 using the Holder's public key passed in a `cnf` claim in the SD-JWT.
@@ -1604,8 +1605,8 @@ After the validation, the Verifier will have the following data for further proc
 
 ## Example 4b - W3C Verifiable Credentials Data Model v2.0
 
-In this example, the artifacts defined in this specification are used to represent a payload
-that is represented as a W3C Verifiable Credentials Data Model v2.0 [@VC_DATA_v2.0].
+This hypothetical example shows how a W3C Verifiable Credentials Data Model v2.0 [@VC_DATA_v2.0]
+payload might be expressed using the artifacts defined in this specification.
 
 Key Binding is applied
 using the Holder's public key passed in a `cnf` claim in the SD-JWT.
@@ -1765,7 +1766,7 @@ data. The original JSON data is then used by the application. See
 * Do not disallow HMAC any longer.
 * Editorial changes aimed at improved clarity
 * Improve unlinkability considerations, mention that different KB keys must be used
-
+* Be more explicit that the VCDM and SD-JWT VC examples are only illustrative and do not define anything
 
    -07
 

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -1458,7 +1458,7 @@ the media type is encoded as an SD-JWT.
 
 Important: The following examples are not normative and provided for
 illustrative purposes only. In particular, neither the structure of the claims
-nor the selection of selectively disclosable claims are normative.
+nor the selection of selectively disclosable claims is normative.
 
 Line breaks have been added for readability.
 

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -1552,8 +1552,8 @@ After the validation, the Verifier will have the following data for further proc
 
 ## Example 4b - W3C Verifiable Credentials Data Model v2.0
 
-This hypothetical example shows how a W3C Verifiable Credentials Data Model v2.0 [@VC_DATA_v2.0]
-payload might be expressed using the artifacts defined in this specification.
+This non-normative example illustrates how the artifacts defined in this specification
+could be used to express a W3C Verifiable Credentials Data Model v2.0 [@VC_DATA_v2.0] payload.
 
 Key Binding is applied
 using the Holder's public key passed in a `cnf` claim in the SD-JWT.


### PR DESCRIPTION
be more explicit that the VCDM and SD-JWT VC examples are only illustrative and do not define anything (for #341)

preview links to the two relevant appendix parts: 
https://drafts.oauth.net/oauth-selective-disclosure-jwt/examples-are-only-examples/draft-ietf-oauth-selective-disclosure-jwt.html#appendix-A

https://drafts.oauth.net/oauth-selective-disclosure-jwt/examples-are-only-examples/draft-ietf-oauth-selective-disclosure-jwt.html#appendix-A.4
