### PR TITLE
Fix the PID example

### DIFF
--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -1538,7 +1538,7 @@ The following Disclosures are created by the Issuer:
 
 {{examples/arf-pid/disclosures.md}}
 
-The following is how a presentation of the SD-JWT with a Key Binding JWT that discloses only nationality and the fact that the person is over 18 years old could look like:
+The following shows a presentation of the SD-JWT with a Key Binding JWT that discloses only the nationality of the Holder:
 
 <{{examples/arf-pid/sd_jwt_presentation.txt}}
 

--- a/examples/arf-pid/specification.yml
+++ b/examples/arf-pid/specification.yml
@@ -1,6 +1,6 @@
 user_claims:
   vct: https://bmi.bund.example/credential/pid/1.0
-  vct#integrity: sha256-jo8433ot48utul8ura33
+  #vct#integrity: sha256-jo8433ot48utul8ura33
   !sd given_name: Erika
   !sd family_name: Mustermann
   !sd birthdate: '1963-08-12'
@@ -37,8 +37,8 @@ user_claims:
 holder_disclosed_claims:
   nationalities:
     - true
-  age_equal_or_over:
-    '18': true
+  #age_equal_or_over:
+  #  '18': true
 
 add_decoy_claims: false
 key_binding: true


### PR DESCRIPTION
Remove `vct#integrity` that is not yet defined and remove the disclosure of the age which for whatever reason didn't work.