### PR TITLE
Add Kotlin & Swift implementations from EUDIW

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ The artifacts generated for the examples (e.g., serialized SD-JWTs, Disclosures,
 
  * Python: [Reference/Demo Implementation](https://github.com/openwallet-foundation-labs/sd-jwt-python)
  * Kotlin: [SD-JWT-Kotlin (ID Union)](https://github.com/IDunion/SD-JWT-Kotlin)
+ * Kotlin: [eudi-lib-jvm-sdjwt (EU Digital Identity Wallet)](https://github.com/eu-digital-identity-wallet/eudi-lib-jvm-sdjwt-kt)
+ * Swift: [eudi-lib-sdjwt-swift (EU Digital Identity Wallet)](https://github.com/eu-digital-identity-wallet/eudi-lib-sdjwt-swift)
  * Rust: [sd_jwt](https://github.com/kushaldas/sd_jwt)
  * TypeScript: [sd-jwt-js](https://github.com/openwallet-foundation-labs/sd-jwt-js)
  * TypeScript: [sd-jwt](https://github.com/christianpaquin/sd-jwt)


### PR DESCRIPTION
This PR updates the README to add two implementations of the SD-JWT specification from [EUDIW](https://github.com/eu-digital-identity-wallet).

* Kotlin: [eudi-lib-jvm-sdjwt (EU Digital Identity Wallet)](https://github.com/eu-digital-identity-wallet/eudi-lib-jvm-sdjwt-kt)
 * Swift: [eudi-lib-sdjwt-swift (EU Digital Identity Wallet)](https://github.com/eu-digital-identity-wallet/eudi-lib-sdjwt-swift)
