### PR TITLE
 ISO/IEC 29100 is too private 

### DIFF
--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -1211,8 +1211,6 @@ Appropriate key management is essential, as any compromise can lead to unauthori
 
 ## Unlinkability {#unlinkability}
 
-The privacy principles of [@ISO.29100] should be adhered to.
-
 Unlinkability is a property whereby adversaries are prevented from correlating
 credential presentations of the same user beyond the user's consent.
 Without unlinkability, an adversary might be able to learn more about the user than the user

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -1219,8 +1219,6 @@ The definition of `typ` in Section 4.1.9 of [@!RFC7515] recommends that the "app
 
 # Privacy Considerations {#privacy_considerations}
 
-The privacy principles of [@ISO.29100] should be adhered to.
-
 ## Unlinkability
 
 Unlinkability is a property whereby adversaries are prevented from correlating
@@ -1568,13 +1566,6 @@ the media type is encoded as an SD-JWT.
       <organization abbrev="Disney (was at Salesforce)">Disney</organization>
     </author>
    <date day="15" month="Dec" year="2023"/>
-  </front>
-</reference>
-
-<reference anchor="ISO.29100" target="https://standards.iso.org/ittf/PubliclyAvailableStandards/index.html">
-  <front>
-    <author fullname="ISO"></author>
-    <title>ISO/IEC 29100:2011 Information technology — Security techniques — Privacy framework</title>
   </front>
 </reference>
 


### PR DESCRIPTION
https://standards.iso.org/ittf/PubliclyAvailableStandards/index.html no longer has anything for 29100 and https://www.iso.org/standard/45123.html indicates that ISO/IEC 29100:2011 is "Withdrawn" and "Revised by" ISO/IEC 29100:2024 that is now available for the low low special price of CHF 129, which is approximately $150 / €137 too much for me to be comfortable referencing