### PR TITLE
Update typ in SD-JWT VC example 

### DIFF
--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -1896,7 +1896,7 @@ data. The original JSON data is then used by the application. See
 
    -14
 
-    * Update the `typ` value in the SD-JWT VC example to `dc+sd-jwt` to align with anticipated changes in the SD-JWT VC draft.
+   * Update the `typ` value in the SD-JWT VC example to `dc+sd-jwt` to align with anticipated changes in the SD-JWT VC draft.
 
    -13
 

--- a/draft-ietf-oauth-selective-disclosure-jwt.md
+++ b/draft-ietf-oauth-selective-disclosure-jwt.md
@@ -1894,6 +1894,10 @@ data. The original JSON data is then used by the application. See
 
    [[ To be removed from the final specification ]]
 
+   -14
+
+    * Update the `typ` value in the SD-JWT VC example to `dc+sd-jwt` to align with anticipated changes in the SD-JWT VC draft.
+
    -13
 
    * WGLC (part 1) updates

--- a/examples/arf-pid/specification.yml
+++ b/examples/arf-pid/specification.yml
@@ -44,4 +44,4 @@ add_decoy_claims: false
 key_binding: true
 
 extra_header_parameters:
-  typ: "vc+sd-jwt"
+  typ: "dc+sd-jwt"


### PR DESCRIPTION
Update the type in the SD-JWT VC example per the The Dublin Accord (last slide of https://datatracker.ietf.org/meeting/121/materials/slides-121-oauth-sessb-sd-jwt-and-sd-jwt-vc-02)